### PR TITLE
fix(zsv): use groovy-specific module excludes

### DIFF
--- a/cbok/bbx/zsv/compile.py
+++ b/cbok/bbx/zsv/compile.py
@@ -3,6 +3,7 @@ ZStack: build changed modules from explicit zstack/premium worktree roots.
 """
 from __future__ import annotations
 
+from collections.abc import Collection
 import hashlib
 import json
 import logging
@@ -51,7 +52,7 @@ _SKIP_JAR_SUFFIXES = (
     "-with-dependencies.jar",
     "-shaded.jar",
 )
-_AUTO_EXCLUDED_MODULES = frozenset(
+DEPLOY_AUTO_EXCLUDED_MODULES = frozenset(
     ("test", "testlib", "test-premium", "testlib-premium")
 )
 MAVEN_PROFILE_PREPARE_CMD = "./runMavenProfile premium"
@@ -451,12 +452,19 @@ def default_compile_deploy_state_store():
     return DjangoCompileDeployStateStore()
 
 
-def _is_auto_excluded(module: str) -> bool:
+def _is_auto_excluded(
+    module: str,
+    excluded_modules: Collection[str] = DEPLOY_AUTO_EXCLUDED_MODULES,
+) -> bool:
     head = module.split("/", 1)[0]
-    return head in _AUTO_EXCLUDED_MODULES
+    return head in excluded_modules
 
 
-def module_for_changed_path(repo_root: str, rel_path: str) -> str | None:
+def module_for_changed_path(
+    repo_root: str,
+    rel_path: str,
+    excluded_modules: Collection[str] = DEPLOY_AUTO_EXCLUDED_MODULES,
+) -> str | None:
     path = Path(str(rel_path).replace("\\", "/"))
     if path.is_absolute() or not path.parts:
         return None
@@ -467,7 +475,7 @@ def module_for_changed_path(repo_root: str, rel_path: str) -> str | None:
     while candidate != root and root in candidate.parents:
         if (candidate / "pom.xml").is_file():
             module = candidate.relative_to(root).as_posix()
-            if _is_auto_excluded(module):
+            if _is_auto_excluded(module, excluded_modules):
                 return None
             return module
         candidate = candidate.parent
@@ -479,17 +487,18 @@ def modules_from_changed_paths(
     main_paths: list[str],
     premium_paths: list[str],
     premium_root: str | None = None,
+    excluded_modules: Collection[str] = DEPLOY_AUTO_EXCLUDED_MODULES,
 ) -> tuple[list[str], list[str]]:
     main: list[str] = []
     for path in main_paths:
-        module = module_for_changed_path(zstack_root, path)
+        module = module_for_changed_path(zstack_root, path, excluded_modules)
         if module:
             main.append(module)
 
     premium: list[str] = []
     premium_root = premium_root or os.path.join(zstack_root, "premium")
     for path in premium_paths:
-        module = module_for_changed_path(premium_root, path)
+        module = module_for_changed_path(premium_root, path, excluded_modules)
         if module:
             premium.append(module)
 
@@ -756,6 +765,7 @@ def _modules_implementing_interfaces(
     repo_root: str,
     interfaces: list[JavaInterfaceChange],
     excluded_roots: list[str] | None = None,
+    excluded_modules: Collection[str] = DEPLOY_AUTO_EXCLUDED_MODULES,
 ) -> list[str]:
     if not interfaces or not os.path.isdir(repo_root):
         return []
@@ -768,7 +778,7 @@ def _modules_implementing_interfaces(
         if not any(_java_implements_interface(source, interface) for interface in interfaces):
             continue
         rel_path = path.relative_to(root).as_posix()
-        module = module_for_changed_path(repo_root, rel_path)
+        module = module_for_changed_path(repo_root, rel_path, excluded_modules)
         if module:
             modules.append(module)
     return _dedupe(modules)
@@ -779,6 +789,7 @@ def infer_interface_implementation_modules(
     premium_root: str | None,
     main_paths: list[str],
     premium_paths: list[str],
+    excluded_modules: Collection[str] = DEPLOY_AUTO_EXCLUDED_MODULES,
 ) -> tuple[list[str], list[str]]:
     interfaces = _java_interfaces_from_changed_paths(zstack_root, main_paths)
     if premium_root and os.path.isdir(premium_root):
@@ -794,16 +805,26 @@ def infer_interface_implementation_modules(
         if _is_under(premium_path, main_root):
             excluded_from_main.append(str(premium_path))
 
-    main = _modules_implementing_interfaces(zstack_root, interfaces, excluded_from_main)
+    main = _modules_implementing_interfaces(
+        zstack_root,
+        interfaces,
+        excluded_from_main,
+        excluded_modules,
+    )
     premium: list[str] = []
     if premium_root and os.path.isdir(premium_root):
-        premium = _modules_implementing_interfaces(premium_root, interfaces)
+        premium = _modules_implementing_interfaces(
+            premium_root,
+            interfaces,
+            excluded_modules=excluded_modules,
+        )
     return _dedupe(main), _dedupe(premium)
 
 
 def auto_detect_modules(
     zstack_root: str,
     premium_root: str | None = None,
+    excluded_modules: Collection[str] = DEPLOY_AUTO_EXCLUDED_MODULES,
 ) -> tuple[list[str], list[str]]:
     premium_root = premium_root or os.path.join(zstack_root, "premium")
     main_worktree_paths = changed_paths_from_worktree(zstack_root)
@@ -815,6 +836,7 @@ def auto_detect_modules(
         main_worktree_paths,
         premium_worktree_paths,
         premium_root,
+        excluded_modules,
     )
 
     main_paths = changed_paths_from_head_commit(zstack_root)
@@ -826,12 +848,14 @@ def auto_detect_modules(
         main_paths,
         premium_paths,
         premium_root,
+        excluded_modules,
     )
     inferred_main, inferred_premium = infer_interface_implementation_modules(
         zstack_root,
         premium_root,
         _dedupe(main_worktree_paths + main_paths),
         _dedupe(premium_worktree_paths + premium_paths),
+        excluded_modules,
     )
     return _dedupe(main + head_main + inferred_main), _dedupe(premium + head_premium + inferred_premium)
 

--- a/cbok/bbx/zsv/groovy_test.py
+++ b/cbok/bbx/zsv/groovy_test.py
@@ -34,6 +34,7 @@ REMOTE_RUN_SCRIPT = "/tmp/cbok-zsv-groovy-run.sh"
 REMOTE_RUN_LOG = "/tmp/cbok-zsv-groovy-run.log"
 REMOTE_RUN_EXIT = "/tmp/cbok-zsv-groovy-run.exit"
 REMOTE_POLL_INTERVAL_SECONDS = 15
+GROOVY_TEST_AUTO_EXCLUDED_MODULES = frozenset(("test", "test-premium"))
 
 
 CORE_HARNESS_BODY = """\
@@ -810,7 +811,11 @@ def _incremental_compile_changed_modules(runner, docker_host: str, handle, work_
     if work_premium.is_dir() and not validate_changed_paths_base_ref(str(work_premium)):
         return 1
 
-    main_mods, prem_mods = auto_detect_modules(str(work_zstack), str(work_premium))
+    main_mods, prem_mods = auto_detect_modules(
+        str(work_zstack),
+        str(work_premium),
+        excluded_modules=GROOVY_TEST_AUTO_EXCLUDED_MODULES,
+    )
     plan = maven_build_plan(main_mods, prem_mods)
     if not plan.modules:
         return 0

--- a/cbok/test/bbx/test_zsv_compile.py
+++ b/cbok/test/bbx/test_zsv_compile.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from cbok.bbx.zsv import compile
+from cbok.bbx.zsv import groovy_test
 from cbok.bbx.zsv import worktree_container
 from cbok.conf import config as cbok_config
 
@@ -427,6 +428,45 @@ class ZsvCompileTest(unittest.TestCase):
 
         self.assertEqual(["utils", "identity"], main)
         self.assertEqual(["volumebackup", "mevoco"], prem)
+
+    def test_auto_detect_modules_uses_groovy_test_excludes_for_test_support_modules(self):
+        compile.settings.CONF = _conf(base_ref="")
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "zstack"
+            premium = Path(td) / "premium"
+            for module in (root / "testlib", premium / "testlib-premium"):
+                module.mkdir(parents=True)
+                (module / "pom.xml").write_text("<project/>", encoding="utf-8")
+
+            def fake_git(repo, *args):
+                repo = os.path.realpath(repo)
+                if args == ("diff", "--name-only", "HEAD"):
+                    return subprocess.CompletedProcess(["git"], 0, "", "")
+                if args == ("ls-files", "--others", "--exclude-standard"):
+                    return subprocess.CompletedProcess(["git"], 0, "", "")
+                if args == ("rev-parse", "--verify", "HEAD^"):
+                    return subprocess.CompletedProcess(["git"], 0, "parent\n", "")
+                if args == ("diff", "--name-only", "HEAD^", "HEAD"):
+                    out = {
+                        os.path.realpath(root): "testlib/src/main/java/org/zstack/testlib/EnvSpec.groovy\n",
+                        os.path.realpath(premium): "testlib-premium/src/main/java/org/zstack/testlib/premium/TestPremium.groovy\n",
+                    }.get(repo, "")
+                    return subprocess.CompletedProcess(["git"], 0, out, "")
+                return subprocess.CompletedProcess(["git"], 0, "", "")
+
+            compile._git = fake_git
+
+            default_main, default_prem = compile.auto_detect_modules(str(root), str(premium))
+            groovy_main, groovy_prem = compile.auto_detect_modules(
+                str(root),
+                str(premium),
+                excluded_modules=groovy_test.GROOVY_TEST_AUTO_EXCLUDED_MODULES,
+            )
+
+        self.assertEqual([], default_main)
+        self.assertEqual([], default_prem)
+        self.assertEqual(["testlib"], groovy_main)
+        self.assertEqual(["testlib-premium"], groovy_prem)
 
     def test_auto_detect_modules_falls_back_to_head_when_no_worktree_module_changed(self):
         compile.settings.CONF = _conf(base_ref="")

--- a/cbok/test/zsv/test_groovy_test.py
+++ b/cbok/test/zsv/test_groovy_test.py
@@ -387,7 +387,13 @@ class GroovyContainerTest(unittest.TestCase):
         runner = FakeRunner()
         work_root = self.root / "run"
         original_auto_detect = groovy_test.auto_detect_modules
-        groovy_test.auto_detect_modules = lambda _zstack, _premium: (["storage"], ["crypto"])
+        seen_excludes = []
+
+        def fake_auto_detect(_zstack, _premium, *, excluded_modules=None):
+            seen_excludes.append(excluded_modules)
+            return ["storage"], ["crypto"]
+
+        groovy_test.auto_detect_modules = fake_auto_detect
         try:
             rc1 = groovy_test.run_groovy_test_flow(
                 zstack_branch="feature-zstack",
@@ -414,6 +420,7 @@ class GroovyContainerTest(unittest.TestCase):
         self.assertEqual(0, rc2)
         shell_scripts = self._shell_scripts(runner)
         self.assertEqual(1, sum("./runMavenProfile premium" in script for script in shell_scripts))
+        self.assertEqual([groovy_test.GROOVY_TEST_AUTO_EXCLUDED_MODULES], seen_excludes)
         self.assertTrue(any(
             "mvn -Ppremium -DskipTests clean install -pl storage,premium/crypto" in script
             for script in shell_scripts
@@ -422,7 +429,7 @@ class GroovyContainerTest(unittest.TestCase):
     def test_different_run_roots_reuse_source_worktree_container(self):
         runner = FakeRunner()
         original_auto_detect = groovy_test.auto_detect_modules
-        groovy_test.auto_detect_modules = lambda _zstack, _premium: (["storage"], ["crypto"])
+        groovy_test.auto_detect_modules = lambda _zstack, _premium, **_kwargs: (["storage"], ["crypto"])
         try:
             rc1 = groovy_test.run_groovy_test_flow(
                 zstack_branch="feature-zstack",


### PR DESCRIPTION
Summary
- Split deploy compile and Groovy test auto-detect exclude sets so normal compile still excludes test support modules.
- Let Groovy test incremental compile use its own exclude set, allowing changed testlib/testlib-premium modules to be detected without manual append logic.
- Add coverage for default vs Groovy test exclude behavior and the Groovy test call contract.

Tests
- `git diff --check`
- `env PYTHONDONTWRITEBYTECODE=1 /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest cbok.test.bbx.test_zsv_compile cbok.test.zsv.test_groovy_test`