### PR TITLE
fix(zsv): use default mode for premium groovy harness

### DIFF
--- a/cbok/bbx/zsv/groovy_test.py
+++ b/cbok/bbx/zsv/groovy_test.py
@@ -96,7 +96,7 @@ class ContainerPremiumGroovyTest extends TestPremium {
 
     @Override
     StartMode getCaseMode() {
-        return StartMode.SIMULATOR
+        return StartMode.DEFAULT
     }
 }
 """

--- a/cbok/test/zsv/test_groovy_test.py
+++ b/cbok/test/zsv/test_groovy_test.py
@@ -626,7 +626,9 @@ class GroovyContainerTest(unittest.TestCase):
             / "premium/test-premium/src/test/groovy/org/zstack/test/ContainerPremiumGroovyTest.groovy"
         )
         self.assertTrue(harness.is_file())
-        self.assertIn("package org.zstack.test", harness.read_text(encoding="utf-8"))
+        harness_text = harness.read_text(encoding="utf-8")
+        self.assertIn("package org.zstack.test", harness_text)
+        self.assertIn("return StartMode.DEFAULT", harness_text)
         run_script = (work_root / "remote-run.sh").read_text(encoding="utf-8")
         self.assertIn("cd /work/zstack/premium/test-premium", run_script)
         self.assertIn("-Dtest=ContainerPremiumGroovyTest", run_script)


### PR DESCRIPTION
Summary
- Run generated `ContainerPremiumGroovyTest` with `StartMode.DEFAULT` so premium Groovy harnesses use the default premium spring/bean startup path.
- Keep the core Groovy harness on `StartMode.SIMULATOR`.
- Add a test assertion covering the generated premium harness mode.

Tests
- `git diff --check`
- `env PYTHONDONTWRITEBYTECODE=1 /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest cbok.test.zsv.test_groovy_test`