### PR TITLE
feat(zsv): add groovy deploy db refresh

### DIFF
--- a/cbok/bbx/zsv/groovy_test.py
+++ b/cbok/bbx/zsv/groovy_test.py
@@ -35,6 +35,13 @@ REMOTE_RUN_LOG = "/tmp/cbok-zsv-groovy-run.log"
 REMOTE_RUN_EXIT = "/tmp/cbok-zsv-groovy-run.exit"
 REMOTE_POLL_INTERVAL_SECONDS = 15
 GROOVY_TEST_AUTO_EXCLUDED_MODULES = frozenset(("test", "test-premium"))
+PREPARED_DB_SCHEMA_FAILURE_PATTERNS = (
+    re.compile(r"Table 'zstack(?:_rest)?\.[^']+' doesn't exist", re.IGNORECASE),
+    re.compile(r"Unknown database 'zstack(?:_rest)?'", re.IGNORECASE),
+    re.compile(r"Unknown column '[^']+'", re.IGNORECASE),
+    re.compile(r"org\.hibernate\.exception\.SQLGrammarException", re.IGNORECASE),
+    re.compile(r"java\.sql\.SQLSyntaxErrorException", re.IGNORECASE),
+)
 
 
 CORE_HARNESS_BODY = """\
@@ -740,6 +747,12 @@ SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='zstack_rest' 
     return len(values) == 3 and values[0] > 100 and values[1] == 1 and values[2] == 1
 
 
+def _looks_like_prepared_db_schema_failure(log_text: str) -> bool:
+    if not log_text:
+        return False
+    return any(pattern.search(log_text) for pattern in PREPARED_DB_SCHEMA_FAILURE_PATTERNS)
+
+
 def _cleanup_worktrees(
         runner,
         zstack_repo: str,
@@ -924,6 +937,7 @@ def _run_remote_container_script(
         container_name: str,
         local_script_file: Path,
         script: str,
+        reuse_deploy_db: bool = False,
 ) -> int:
     _write_file(local_script_file, script)
     rc = _docker_cp_file_to_container(
@@ -989,8 +1003,14 @@ def _run_remote_container_script(
     if _returncode(log_result) != 0:
         return _returncode(log_result)
 
+    log_text = log_result.stdout or ""
     if rc != 0:
         LOG.error("Remote container test script failed: %s", rc)
+        if reuse_deploy_db and _looks_like_prepared_db_schema_failure(log_text):
+            LOG.error(
+                "AI hint: prepared Groovy test database may be stale or corrupted. "
+                "Retry with --refresh-deploy-db to rebuild it."
+            )
     return rc
 
 
@@ -1112,6 +1132,7 @@ def run_groovy_test_flow(
         m2_dir: str | None = None,
         run_id: str | None = None,
         keep_worktree: bool = True,
+        refresh_deploy_db: bool = False,
         runner=None,
 ) -> int:
     if not _validate_inputs(test_class, test_mode):
@@ -1228,9 +1249,11 @@ def run_groovy_test_flow(
         if rc != 0:
             return rc
 
-    reuse_deploy_db = _container_db_is_ready(runner, docker_host, handle.container_name)
+    reuse_deploy_db = False if refresh_deploy_db else _container_db_is_ready(runner, docker_host, handle.container_name)
     if reuse_deploy_db:
         LOG.info("Reusing prepared Groovy test database in %s.", handle.container_name)
+    elif refresh_deploy_db:
+        LOG.info("Refreshing Groovy test database in %s.", handle.container_name)
 
     if target.needs_case_file:
         rc = _docker_cp_file_to_container(
@@ -1249,4 +1272,5 @@ def run_groovy_test_flow(
         handle.container_name,
         root / "remote-run.sh",
         build_container_test_script(target, handle.workdir, reuse_deploy_db),
+        reuse_deploy_db=reuse_deploy_db,
     )

--- a/cbok/cmd/zsv.py
+++ b/cbok/cmd/zsv.py
@@ -386,6 +386,9 @@ class ZSphereCommands(base.BaseCommand):
     @args.args(
         "--refresh-worktree", action="store_true",
         help="Replace the generated zstack/premium worktree before the run")
+    @args.args(
+        "--refresh-deploy-db", action="store_true",
+        help="Redeploy the Groovy test database instead of reusing a prepared database")
     def groovy_test(
             self,
             zstack_branch=None,
@@ -397,6 +400,7 @@ class ZSphereCommands(base.BaseCommand):
             work_root=None,
             run_id=None,
             refresh_worktree=False,
+            refresh_deploy_db=False,
     ):
         """Run a ZStack Groovy integration test in a reusable Docker container"""
         return run_groovy_test_flow(
@@ -409,6 +413,7 @@ class ZSphereCommands(base.BaseCommand):
             work_root=work_root,
             run_id=run_id,
             keep_worktree=not refresh_worktree,
+            refresh_deploy_db=refresh_deploy_db,
             runner=self.p_runner,
         )
 

--- a/cbok/test/zsv/test_groovy_test.py
+++ b/cbok/test/zsv/test_groovy_test.py
@@ -14,6 +14,8 @@ class FakeRunner:
     def __init__(self):
         self.commands = []
         self.containers = set()
+        self.remote_run_exit = "0\n"
+        self.remote_run_log = "ok\n"
 
     def run_command(self, cmd, **kwargs):
         self.commands.append((cmd, kwargs))
@@ -38,9 +40,9 @@ class FakeRunner:
                 self.containers.add(parts[parts.index("--name") + 1])
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
         if "cat /tmp/cbok-zsv-groovy-run.exit" in script:
-            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="0\n", stderr="")
-        if "cat /tmp/cbok-zsv-groovy-run.log" in script:
-            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="ok\n", stderr="")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=self.remote_run_exit, stderr="")
+        if "tail -n " in script and "/tmp/cbok-zsv-groovy-run.log" in script:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=self.remote_run_log, stderr="")
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
 
@@ -301,6 +303,60 @@ class GroovyContainerTest(unittest.TestCase):
         run_script = (work_root / "remote-run.sh").read_text(encoding="utf-8")
         self.assertIn("-DcbokReuseDeployDb=true", run_script)
         self.assertIn('if (Boolean.getBoolean("cbokReuseDeployDb"))', run_script)
+
+    def test_refresh_deploy_db_ignores_prepared_deploy_db(self):
+        runner = FakeRunner()
+        work_root = self.root / "run"
+        original_db_ready = groovy_test._container_db_is_ready
+        groovy_test._container_db_is_ready = lambda _runner, _docker_host, _container_name: True
+        try:
+            rc = groovy_test.run_groovy_test_flow(
+                zstack_branch="feature-zstack",
+                premium_branch="feature-premium",
+                test_class="org.zstack.test.integration.core.MustPassCase",
+                zstack_repo=str(self.zstack_repo),
+                premium_repo=str(self.premium_repo),
+                work_root=str(work_root),
+                refresh_deploy_db=True,
+                runner=runner,
+            )
+        finally:
+            groovy_test._container_db_is_ready = original_db_ready
+
+        self.assertEqual(0, rc)
+        run_script = (work_root / "remote-run.sh").read_text(encoding="utf-8")
+        self.assertNotIn("-DcbokReuseDeployDb=true", run_script)
+        self.assertNotIn('if (Boolean.getBoolean("cbokReuseDeployDb"))', run_script)
+
+    def test_reused_prepared_deploy_db_schema_failure_suggests_refresh(self):
+        runner = FakeRunner()
+        runner.remote_run_exit = "1\n"
+        runner.remote_run_log = (
+            "org.hibernate.exception.SQLGrammarException: could not execute statement\n"
+            "java.sql.SQLSyntaxErrorException: Table 'zstack.ManagementNodeVO' doesn't exist\n"
+        )
+        work_root = self.root / "run"
+        original_db_ready = groovy_test._container_db_is_ready
+        groovy_test._container_db_is_ready = lambda _runner, _docker_host, _container_name: True
+        try:
+            with self.assertLogs(groovy_test.LOG, level="ERROR") as logs:
+                rc = groovy_test.run_groovy_test_flow(
+                    zstack_branch="feature-zstack",
+                    premium_branch="feature-premium",
+                    test_class="org.zstack.test.integration.core.MustPassCase",
+                    zstack_repo=str(self.zstack_repo),
+                    premium_repo=str(self.premium_repo),
+                    work_root=str(work_root),
+                    runner=runner,
+                )
+        finally:
+            groovy_test._container_db_is_ready = original_db_ready
+
+        self.assertEqual(1, rc)
+        self.assertIn(
+            "Retry with --refresh-deploy-db",
+            "\n".join(logs.output),
+        )
 
     def test_default_run_root_can_already_exist_for_run_id_reuse(self):
         runner = FakeRunner()


### PR DESCRIPTION
Summary
- Add `--refresh-deploy-db` to `cbok zsv groovy_test` so a run can rebuild the Groovy test database instead of reusing the prepared DB.
- Detect schema-shaped failures from reused prepared DB logs and print an AI hint to retry with `--refresh-deploy-db`.
- Cover refresh behavior and stale/corrupted prepared DB failure hints in unit tests.

Tests
- `/Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest cbok.test.zsv.test_groovy_test`
- `git diff --check origin/master...HEAD`