### PR TITLE
feat(config): support CBOK_CONF override

### DIFF
--- a/cbok/conf/files.py
+++ b/cbok/conf/files.py
@@ -1,0 +1,15 @@
+import configparser
+import os
+
+
+def resolve_cbok_conf_path(base_dir):
+    conf_path = os.environ.get("CBOK_CONF", "").strip()
+    if conf_path:
+        return os.path.abspath(os.path.expanduser(os.path.expandvars(conf_path)))
+    return os.path.join(base_dir, "cbok.conf")
+
+
+def read_cbok_conf(conf_path):
+    conf = configparser.ConfigParser()
+    conf.read(conf_path)
+    return conf

--- a/cbok/settings.py
+++ b/cbok/settings.py
@@ -1,17 +1,17 @@
-import configparser
 import os
 import sys
 
 from oslo_utils import strutils
 
 from cbok.conf import config
+from cbok.conf.files import read_cbok_conf, resolve_cbok_conf_path
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, BASE_DIR)
 
-CONF = configparser.ConfigParser()
-CONF.read(os.path.join(BASE_DIR, "cbok.conf"))
+CBOK_CONF_PATH = resolve_cbok_conf_path(BASE_DIR)
+CONF = read_cbok_conf(CBOK_CONF_PATH)
 config.validate_section_strict(CONF)
 
 # SECURITY WARNING: keep the secret key used in production secret!

--- a/cbok/test/test_conf_files.py
+++ b/cbok/test/test_conf_files.py
@@ -1,0 +1,46 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from cbok.conf.files import read_cbok_conf, resolve_cbok_conf_path
+
+
+class CbokConfFilesTest(unittest.TestCase):
+    def test_resolve_cbok_conf_path_defaults_to_repo_root(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            path = resolve_cbok_conf_path("/repo/root")
+
+        self.assertEqual("/repo/root/cbok.conf", path)
+
+    def test_resolve_cbok_conf_path_uses_env_override(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_path = os.path.join(tmpdir, "custom.conf")
+            with mock.patch.dict(os.environ, {"CBOK_CONF": raw_path}):
+                path = resolve_cbok_conf_path("/repo/root")
+
+        self.assertEqual(raw_path, path)
+
+    def test_resolve_cbok_conf_path_expands_user_and_env(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "CBOK_CONF_DIR": tmpdir,
+                    "CBOK_CONF": "$CBOK_CONF_DIR/../custom.conf",
+                },
+            ):
+                path = resolve_cbok_conf_path("/repo/root")
+
+        self.assertEqual(str(Path(tmpdir).parent / "custom.conf"), path)
+
+    def test_read_cbok_conf_reads_resolved_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conf_path = os.path.join(tmpdir, "cbok.conf")
+            with open(conf_path, "w", encoding="utf-8") as fp:
+                fp.write("[default]\nworkspace = /tmp/cbok\n")
+
+            conf = read_cbok_conf(conf_path)
+
+        self.assertEqual("/tmp/cbok", conf.get("default", "workspace"))


### PR DESCRIPTION
## Summary
- Allow CBoK settings to read config from `CBOK_CONF` before falling back to the checkout-local `cbok.conf`.
- Move config path resolution into a small helper and add focused unit coverage for default, env override, expansion, and config reading.

## Tests
- `CBOK_CONF=/Users/mizar/Workspace/Cursor/me/cbok/cbok.conf /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest discover -s cbok/test`
- `git diff --check`