### PR TITLE
feat(zsv): require configured base ref

### DIFF
--- a/cbok/bbx/zsv/compile.py
+++ b/cbok/bbx/zsv/compile.py
@@ -26,7 +26,6 @@ from cbok import settings
 from cbok.bbx.models import ZsvCompileState
 from cbok.bbx.zsv import base_ref as zsv_base_ref
 from cbok.bbx.zsv import config as zsv_config
-from cbok.bbx.zsv.config import DEFAULT_BASE_REF
 from cbok.bbx.zsv.config import default_zstack_root
 from cbok.bbx.zsv.config import zstack_root_from_workspace
 from cbok.bbx.zsv.worktree_container import DEFAULT_MIN_FREE_GB
@@ -516,7 +515,8 @@ def sync_changed_paths_base_ref(repo_root: str) -> bool:
 def validate_changed_paths_base_ref(repo_root: str) -> bool:
     base_ref = zsv_config.zsv_base_ref()
     if not base_ref:
-        return True
+        LOG.error("ZSV base_ref is not configured; set [zsv] base_ref in cbok.conf.")
+        return False
 
     if not sync_changed_paths_base_ref(repo_root):
         return False

--- a/cbok/bbx/zsv/config.py
+++ b/cbok/bbx/zsv/config.py
@@ -5,20 +5,10 @@ import os
 from cbok import settings
 
 
-DEFAULT_BASE_REF = "origin/feature-zsv-5.1.0-encryption"
-
-
-def _conf_get(section: str, option: str, default: str) -> str:
-    conf = settings.CONF
-    if conf.has_section(section) and conf.has_option(section, option):
-        return conf.get(section, option).strip()
-    return default
-
-
 def zsv_base_ref() -> str:
     if settings.CONF.has_section("zsv") and settings.CONF.has_option("zsv", "base_ref"):
         return settings.CONF.get("zsv", "base_ref").strip()
-    return _conf_get("zsv_compile", "base_ref", DEFAULT_BASE_REF)
+    return ""
 
 
 def default_zstack_root() -> str:

--- a/cbok/cmd/zsv.py
+++ b/cbok/cmd/zsv.py
@@ -28,6 +28,7 @@ from cbok.bbx.zsv.service import ZsvHostDiscoveryError
 from cbok.bbx.zsv.compile import DEFAULT_REMOTE_LIB
 from cbok.bbx.zsv.compile import remote_docker_compile_from_conf
 from cbok.bbx.zsv.compile import run_compile_flow
+from cbok.bbx.zsv import config as zsv_config
 from cbok.bbx.zsv.groovy_test import run_groovy_test_flow
 from cbok.bbx.zsv.worktree_prune import list_worktree_container_prs
 from cbok.bbx.zsv.worktree_prune import prune_worktree_containers
@@ -110,6 +111,11 @@ def _print_iso(tracker, iso, state, needs_upgrade):
     print(f"Last sync at: {upgraded_at}")
     if needs_upgrade:
         print(f"---\n{_upgrade_command(tracker)}")
+
+
+def _log_zsv_base_ref():
+    base_ref = zsv_config.zsv_base_ref() or "<not configured>"
+    LOG.info("ZSV base ref: %s", base_ref)
 
 
 class ZSphereCommands(base.BaseCommand):
@@ -287,6 +293,7 @@ class ZSphereCommands(base.BaseCommand):
             primary_node=None,
     ):
         """Upgrade ZSphere primary node with latest BIN/ISO package"""
+        _log_zsv_base_ref()
         tracker = self._tracker(
             name=name,
             upgrade_url=upgrade_url,
@@ -335,6 +342,7 @@ class ZSphereCommands(base.BaseCommand):
         Build changed modules in a remote Docker worktree container.
         Deploy copies JARs to remote WEB-INF/lib (with backup).
         """
+        _log_zsv_base_ref()
         deploy = not no_deploy
         if deploy:
             if not address:
@@ -403,6 +411,7 @@ class ZSphereCommands(base.BaseCommand):
             refresh_deploy_db=False,
     ):
         """Run a ZStack Groovy integration test in a reusable Docker container"""
+        _log_zsv_base_ref()
         return run_groovy_test_flow(
             zstack_branch=zstack_branch,
             premium_branch=premium_branch,
@@ -473,6 +482,7 @@ class ZSphereCommands(base.BaseCommand):
         """
         Replace changed kvmagent/zstacklib/ceph/zbs primary agent files on ZSV nodes.
         """
+        _log_zsv_base_ref()
         if not primary_node:
             LOG.error("replace_agent requires --primary-node.")
             return 1
@@ -523,6 +533,7 @@ class ZSphereCommands(base.BaseCommand):
         help="zstack-store checkout root for the current worktree")
     def replace_zstore(self, primary_node=None, zstore_root=None):
         """Build and replace zstore and zstcli on healthy KVM hosts and ImageStore backup storage nodes"""
+        _log_zsv_base_ref()
         if not primary_node or not zstore_root:
             LOG.error("replace_zstore requires --primary-node and --zstore-root.")
             return 1

--- a/cbok/conf/config.py
+++ b/cbok/conf/config.py
@@ -76,8 +76,10 @@ ZSV = Group(
     name="zsv",
     title="zsv shared settings",
     options=[
-        Option("base_ref", default="origin/feature-zsv-5.1.0-encryption",
-        help="Remote branch used as the shared ZSV base ref"),
+        Option(
+            "base_ref",
+            help="Remote branch used as the shared ZSV base ref",
+        ),
     ]
 )
 

--- a/cbok/test/bbx/test_zsv_compile.py
+++ b/cbok/test/bbx/test_zsv_compile.py
@@ -57,6 +57,10 @@ class FakeRunner:
 def _conf(**values):
     parser = configparser.ConfigParser()
     parser.add_section("zsv_compile")
+    base_ref = values.pop("base_ref", None)
+    if base_ref is not None:
+        parser.add_section("zsv")
+        parser.set("zsv", "base_ref", str(base_ref))
     for key, value in values.items():
         parser.set("zsv_compile", key, str(value))
     return parser
@@ -68,6 +72,7 @@ class ZsvCompileTest(unittest.TestCase):
         self._orig_auto_detect_modules = compile.auto_detect_modules
         self._orig_git_summary = compile.git_summary
         self._orig_git = compile._git
+        self._orig_validate_changed_paths_base_ref = compile.validate_changed_paths_base_ref
         self._orig_local_jar_copy_root_for_root = compile._local_jar_copy_root_for_root
         self._orig_collect_changed_web_classes_files = compile.collect_changed_web_classes_files
         self._orig_default_compile_state_store = compile.default_compile_deploy_state_store
@@ -82,10 +87,14 @@ class ZsvCompileTest(unittest.TestCase):
         compile.auto_detect_modules = self._orig_auto_detect_modules
         compile.git_summary = self._orig_git_summary
         compile._git = self._orig_git
+        compile.validate_changed_paths_base_ref = self._orig_validate_changed_paths_base_ref
         compile._local_jar_copy_root_for_root = self._orig_local_jar_copy_root_for_root
         compile.collect_changed_web_classes_files = self._orig_collect_changed_web_classes_files
         compile.default_compile_deploy_state_store = self._orig_default_compile_state_store
         worktree_container.default_state_store = self._orig_default_state_store
+
+    def _allow_changed_paths_base_ref_validation(self):
+        compile.validate_changed_paths_base_ref = lambda _root: True
 
     def test_remote_docker_conf_reads_optional_values(self):
         compile.settings.CONF = _conf(
@@ -149,6 +158,17 @@ class ZsvCompileTest(unittest.TestCase):
             ("merge-base", "--is-ancestor", "origin/feature/zsv", "HEAD"),
         ], calls)
 
+    def test_validate_changed_paths_base_ref_requires_configured_base_ref(self):
+        compile.settings.CONF = _conf()
+
+        with self.assertLogs(compile.LOG.name, level="ERROR") as logs:
+            self.assertFalse(compile.validate_changed_paths_base_ref("/repo"))
+
+        self.assertIn(
+            "ZSV base_ref is not configured",
+            "\n".join(logs.output),
+        )
+
     def test_zsv_compile_config_does_not_expose_profile_switch(self):
         option_names = [opt.name for opt in cbok_config.ZSV_COMPILE.options]
         zsv_option_names = [opt.name for opt in cbok_config.ZSV.options]
@@ -179,8 +199,9 @@ class ZsvCompileTest(unittest.TestCase):
         compile.settings.CONF = _conf(
             remote_docker_host="tcp://172.26.50.70:2375",
             remote_docker_image="zstack-buildbin:debug7-arm64",
-            base_ref="",
+            base_ref="origin/test-base",
         )
+        self._allow_changed_paths_base_ref_validation()
         compile.auto_detect_modules = lambda _root, _premium_root=None: (["plugin/foo"], [])
         compile.git_summary = lambda _root: ("abc123 test", "abc123")
 
@@ -222,8 +243,9 @@ class ZsvCompileTest(unittest.TestCase):
             remote_docker_host="http://172.26.50.70:2375",
             remote_docker_workdir="/work",
             remote_docker_m2_volume="zsv-m2",
-            base_ref="",
+            base_ref="origin/test-base",
         )
+        self._allow_changed_paths_base_ref_validation()
         compile.auto_detect_modules = lambda _root, _premium_root=None: (["plugin/foo"], [])
         compile.git_summary = lambda _root: ("abc123 test", "abc123")
 
@@ -686,7 +708,8 @@ class ZsvCompileTest(unittest.TestCase):
         self.assertEqual(str(premium_xml.resolve()), mapped["springConfigXml/crypto.xml"])
 
     def test_explicit_web_class_overrides_changed_file_with_same_target(self):
-        compile.settings.CONF = _conf(remote_docker_host="tcp://172.26.50.70:2375", base_ref="")
+        compile.settings.CONF = _conf(remote_docker_host="tcp://172.26.50.70:2375", base_ref="origin/test-base")
+        self._allow_changed_paths_base_ref_validation()
         compile.auto_detect_modules = lambda _root, _premium_root=None: (["identity"], [])
         compile.git_summary = lambda _root: ("abc123 test", "abc123")
 
@@ -733,7 +756,8 @@ class ZsvCompileTest(unittest.TestCase):
         self.assertNotIn(str(zstack_xml.resolve()), output)
 
     def test_deploy_uses_unique_remote_staging_per_compile(self):
-        compile.settings.CONF = _conf(remote_docker_host="tcp://172.26.50.70:2375", base_ref="")
+        compile.settings.CONF = _conf(remote_docker_host="tcp://172.26.50.70:2375", base_ref="origin/test-base")
+        self._allow_changed_paths_base_ref_validation()
         compile.auto_detect_modules = lambda _root, _premium_root=None: (["identity"], [])
         compile.git_summary = lambda _root: ("abc123 test", "abc123")
 
@@ -785,7 +809,8 @@ class ZsvCompileTest(unittest.TestCase):
         self.assertNotIn(str(worktree_target / "identity-5.0.0.jar"), scp_scripts[0])
 
     def test_deploy_syncs_changed_web_classes_archive(self):
-        compile.settings.CONF = _conf(remote_docker_host="tcp://172.26.50.70:2375", base_ref="")
+        compile.settings.CONF = _conf(remote_docker_host="tcp://172.26.50.70:2375", base_ref="origin/test-base")
+        self._allow_changed_paths_base_ref_validation()
         compile.auto_detect_modules = lambda _root, _premium_root=None: (["identity"], [])
         compile.git_summary = lambda _root: ("abc123 test", "abc123")
 
@@ -828,7 +853,8 @@ class ZsvCompileTest(unittest.TestCase):
         self.assertTrue(any("/usr/local/zstack/apache-tomcat/webapps/zstack/WEB-INF/classes" in script for script in shell_scripts))
 
     def test_deploy_replays_previous_modules_removed_from_current_diff(self):
-        compile.settings.CONF = _conf(remote_docker_host="tcp://172.26.50.70:2375", base_ref="")
+        compile.settings.CONF = _conf(remote_docker_host="tcp://172.26.50.70:2375", base_ref="origin/test-base")
+        self._allow_changed_paths_base_ref_validation()
         compile.auto_detect_modules = lambda _root, _premium_root=None: (["identity"], [])
         compile.collect_changed_web_classes_files = lambda _root, _premium_root=None: []
         compile.git_summary = lambda _root: ("abc123 test", "abc123")
@@ -880,7 +906,8 @@ class ZsvCompileTest(unittest.TestCase):
         self.assertEqual([], selection.premium_modules)
 
     def test_deploy_replays_previous_web_classes_when_current_diff_is_empty(self):
-        compile.settings.CONF = _conf(remote_docker_host="tcp://172.26.50.70:2375", base_ref="")
+        compile.settings.CONF = _conf(remote_docker_host="tcp://172.26.50.70:2375", base_ref="origin/test-base")
+        self._allow_changed_paths_base_ref_validation()
         compile.auto_detect_modules = lambda _root, _premium_root=None: ([], [])
         compile.collect_changed_web_classes_files = lambda _root, _premium_root=None: []
         compile.git_summary = lambda _root: ("abc123 test", "abc123")

--- a/cbok/test/zsv/test_config.py
+++ b/cbok/test/zsv/test_config.py
@@ -34,12 +34,12 @@ class ZsvConfigTest(unittest.TestCase):
 
         self.assertEqual("origin/shared", zsv_config.zsv_base_ref())
 
-    def test_base_ref_falls_back_to_legacy_compile_config(self):
+    def test_base_ref_does_not_fall_back_to_legacy_compile_config(self):
         zsv_config.settings.CONF = _conf(
             zsv_compile_values={"base_ref": "origin/legacy"},
         )
 
-        self.assertEqual("origin/legacy", zsv_config.zsv_base_ref())
+        self.assertEqual("", zsv_config.zsv_base_ref())
 
     def test_zstack_root_is_derived_from_workspace(self):
         zsv_config.settings.CONF = _conf(zsv_values={"zstack_root": "/ignored/zstack"})

--- a/cbok/test/zsv/test_schema_repair.py
+++ b/cbok/test/zsv/test_schema_repair.py
@@ -484,8 +484,10 @@ class SchemaRepairTest(unittest.TestCase):
     def test_zsv_shared_settings_configure_base_ref_only(self):
         self.assertIn("zsv", [group.name for group in cbok_config.ALL_GROUPS])
         option_names = [opt.name for opt in cbok_config.ZSV.options]
+        base_ref = next(opt for opt in cbok_config.ZSV.options if opt.name == "base_ref")
 
         self.assertIn("base_ref", option_names)
+        self.assertIsNone(base_ref.default)
         self.assertNotIn("zstack_root", option_names)
         self.assertNotIn("schema_branch", option_names)
         self.assertNotIn("db_file", option_names)


### PR DESCRIPTION
## Summary
- require ZSV base_ref to come from [zsv] base_ref instead of a built-in default or legacy zsv_compile fallback
- log the configured ZSV base ref explicitly for zsv commands that need it: upgrade, compile, groovy_test, replace_agent, and replace_zstore
- add tests for required base_ref behavior

## Tests
- `CBOK_CONF=/Users/mizar/Workspace/Cursor/me/cbok/cbok.conf /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest discover -s cbok/test` (144 tests OK)
- `git diff --check`