### PR TITLE
Fix ZSV upgrade schema precheck from artifact SQL

### DIFF
--- a/cbok/bbx/zsv/README.md
+++ b/cbok/bbx/zsv/README.md
@@ -63,12 +63,14 @@ Behavior:
 
 ## ZSphere upgrade schema file
 
-`cbok zsv upgrade` fetches the configured `[zsv] base_ref` in the local ZStack
-checkout, reads `conf/db/zsv/V5.1.0__schema.sql` from that ref, and uses the
-temporary copy for a pre-upgrade Flyway checksum check. If Flyway reports a
-checksum mismatch, cbok stops before upgrade and asks the AI to use the
-`cbok-zsv-upgrade-db-repair` skill. cbok does not apply schema SQL or run
-`flyway repair` automatically.
+`cbok zsv upgrade` downloads or reuses the exact BIN/ISO package on the primary
+node, parses the target version from the package name or URL, and extracts the
+matching `WEB-INF/classes/db/zsv/V<version>__*.sql` file. The matching SQL must
+exist exactly once; missing or multiple matches stop the command. If that
+script already has a successful `zstack.schema_version` row, cbok compares its
+Flyway checksum before upgrade. If the checksum differs, cbok stops before
+upgrade and asks the AI to use the `cbok-zsv-upgrade-db-repair` skill. cbok does
+not apply schema SQL or run `flyway repair` automatically.
 
 ## Worktree container cleanup
 

--- a/cbok/bbx/zsv/schema_repair.py
+++ b/cbok/bbx/zsv/schema_repair.py
@@ -10,17 +10,12 @@ import shutil
 import subprocess
 import tempfile
 
-from cbok.bbx.zsv import base_ref as zsv_base_ref_helper
-from cbok.bbx.zsv.config import zsv_base_ref
-from cbok.bbx.zsv.config import zstack_root_from_workspace
-
 
 LOG = logging.getLogger(__name__)
 
 DEFAULT_REMOTE_SQL_DIR = "/tmp/cbok-zsv-schema-sql"
-ZSV_DB_DIR = "conf/db/zsv"
-DEFAULT_ZSV_SCHEMA_DB_FILE = os.path.join(ZSV_DB_DIR, "V5.1.0__schema.sql")
 MANUAL_REPAIR_SKILL = "cbok-zsv-upgrade-db-repair"
+ARTIFACT_PRECHECK_MARKER = "__CBOK_ZSV_SCHEMA_PRECHECK__"
 
 
 @dataclass(frozen=True)
@@ -38,14 +33,6 @@ class ChecksumMismatch:
     resolved_checksum: int
 
 
-def _git(root: str, *args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["git", "-C", root, *args],
-        capture_output=True,
-        text=True,
-    )
-
-
 def _sql_string(value: str) -> str:
     return "'" + value.replace("\\", "\\\\").replace("'", "''") + "'"
 
@@ -55,33 +42,6 @@ def _version_from_script(script: str) -> str:
     if not m:
         raise ValueError(f"cannot parse migration version from {script}")
     return m.group("version")
-
-
-def read_branch_file(zstack_root: str, branch: str, path: str) -> str:
-    result = _git(zstack_root, "show", f"{branch}:{path}")
-    if result.returncode != 0:
-        raise RuntimeError((result.stderr or result.stdout or "").strip())
-    return result.stdout or ""
-
-
-def materialize_zsv_schema_db_file(
-    *,
-    target_dir: str,
-    zstack_root: str | None = None,
-) -> str:
-    base_ref = zsv_base_ref()
-    if not base_ref:
-        raise RuntimeError("zsv base_ref is not configured")
-
-    root = os.path.realpath(zstack_root) if zstack_root else zstack_root_from_workspace()
-    if not zsv_base_ref_helper.sync_base_ref(root):
-        raise RuntimeError(f"failed to sync zsv base_ref {base_ref}")
-
-    content = read_branch_file(root, base_ref, DEFAULT_ZSV_SCHEMA_DB_FILE)
-    Path(target_dir).mkdir(parents=True, exist_ok=True)
-    target = Path(target_dir, os.path.basename(DEFAULT_ZSV_SCHEMA_DB_FILE))
-    target.write_text(content, encoding="utf-8")
-    return str(target)
 
 
 def parse_checksum_mismatches(output: str) -> list[ChecksumMismatch]:
@@ -107,6 +67,15 @@ def _bash_scriptlet(expr: str) -> list[str]:
 
 def _run_scriptlet(runner, expr: str):
     return runner.run_command(_bash_scriptlet(expr), cmd_purge_output=False)
+
+
+def _run_scriptlet_quiet(runner, expr: str):
+    return runner.run_command(
+        _bash_scriptlet(expr),
+        cmd_purge_output=False,
+        log_output=False,
+        log_failed_status=False,
+    )
 
 
 def _remote_mysql_query(address: str, sql: str, runner) -> subprocess.CompletedProcess[str]:
@@ -183,6 +152,74 @@ def format_manual_repair_hint(
         f"resolved checksum: {mismatch.resolved_checksum}",
         f"SQL source: {db_file}",
     ])
+
+
+def _parse_artifact_precheck_report(output: str) -> dict[str, str]:
+    lines = (output or "").splitlines()
+    try:
+        start = lines.index(ARTIFACT_PRECHECK_MARKER) + 1
+    except ValueError:
+        return {}
+
+    fields: dict[str, str] = {}
+    for line in lines[start:]:
+        if not line.strip():
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        fields[key.strip()] = value.strip()
+    return fields
+
+
+def run_schema_mismatch_precheck_for_artifact(
+    *,
+    address: str,
+    artifact_url: str,
+    artifact_name: str,
+    artifact_modified: str = "",
+    artifact_size: str = "",
+    upgrade_type: str,
+    runner,
+) -> int:
+    result = _run_scriptlet_quiet(
+        runner,
+        "zsv_schema_precheck_artifact "
+        f"{shlex.quote(address)} "
+        f"{shlex.quote(artifact_url)} "
+        f"{shlex.quote(artifact_name)} "
+        f"{shlex.quote(artifact_modified or '')} "
+        f"{shlex.quote(artifact_size or '')} "
+        f"{shlex.quote(upgrade_type)}",
+    )
+    returncode = getattr(result, "returncode", 1) or 0
+    if returncode == 0:
+        return 0
+
+    output = result.stdout or result.stderr or ""
+    fields = _parse_artifact_precheck_report(output)
+    if not fields:
+        LOG.error("ZSV schema artifact precheck failed.\n%s", output.strip())
+        return returncode
+
+    migration = AppliedMigration(
+        version=fields.get("version", ""),
+        version_rank=int(fields.get("version_rank") or 0),
+        checksum=int(fields.get("applied_checksum") or 0),
+        script=fields.get("script", ""),
+    )
+    mismatch = ChecksumMismatch(
+        version=fields.get("version", ""),
+        applied_checksum=int(fields.get("applied_checksum") or 0),
+        resolved_checksum=int(fields.get("resolved_checksum") or 0),
+    )
+    LOG.error(format_manual_repair_hint(
+        address=fields.get("primary_node") or address,
+        migration=migration,
+        mismatch=mismatch,
+        db_file=fields.get("sql_source") or fields.get("artifact_path") or artifact_name,
+    ))
+    return 1
 
 
 def run_schema_mismatch_precheck_for_file(

--- a/cbok/bbx/zsv/service.py
+++ b/cbok/bbx/zsv/service.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 import shlex
-import tempfile
 from urllib.parse import unquote
 from urllib.parse import urlparse
 
@@ -388,18 +387,15 @@ class ZSphereTracker:
             if getattr(result, "returncode", 0) != 0:
                 return result.returncode, iso, state
 
-        with tempfile.TemporaryDirectory() as td:
-            try:
-                db_file = schema_repair.materialize_zsv_schema_db_file(target_dir=td)
-            except RuntimeError as exc:
-                LOG.error("Failed to resolve ZSV schema db file from base ref: %s", exc)
-                return 1, iso, state
-
-            schema_precheck_rc = schema_repair.run_schema_mismatch_precheck_for_file(
-                address=self.primary_node,
-                db_file=db_file,
-                runner=self.runner,
-            )
+        schema_precheck_rc = schema_repair.run_schema_mismatch_precheck_for_artifact(
+            address=self.primary_node,
+            artifact_url=iso.download_url,
+            artifact_name=iso.name,
+            artifact_modified=self._iso_modified_arg(iso),
+            artifact_size=iso.size or "",
+            upgrade_type=self.upgrade_type,
+            runner=self.runner,
+        )
         if schema_precheck_rc != 0:
             return schema_precheck_rc, iso, state
 

--- a/cbok/cmd/zsv.py
+++ b/cbok/cmd/zsv.py
@@ -293,7 +293,6 @@ class ZSphereCommands(base.BaseCommand):
             primary_node=None,
     ):
         """Upgrade ZSphere primary node with latest BIN/ISO package"""
-        _log_zsv_base_ref()
         tracker = self._tracker(
             name=name,
             upgrade_url=upgrade_url,

--- a/cbok/test/zsv/test_schema_repair.py
+++ b/cbok/test/zsv/test_schema_repair.py
@@ -50,12 +50,6 @@ class FakeCommand:
         return SimpleNamespace(returncode=0)
 
 
-def fake_materialize_schema_db_file(target_dir, **_kwargs):
-    path = Path(target_dir, "V5.1.0__schema.sql")
-    path.write_text("CREATE TABLE T(id int);\n", encoding="utf-8")
-    return str(path)
-
-
 class SchemaRepairTest(unittest.TestCase):
     def test_discover_management_nodes_ignores_ssh_banner_lines(self):
         class Runner:
@@ -185,11 +179,9 @@ class SchemaRepairTest(unittest.TestCase):
             runner=runner,
         )
         original_discover = zsv_service.discover_management_nodes
-        original_precheck = schema_repair.run_schema_mismatch_precheck_for_file
-        original_materialize = schema_repair.materialize_zsv_schema_db_file
+        original_precheck = schema_repair.run_schema_mismatch_precheck_for_artifact
         zsv_service.discover_management_nodes = lambda address, runner: [address]
-        schema_repair.run_schema_mismatch_precheck_for_file = lambda **kwargs: 0
-        schema_repair.materialize_zsv_schema_db_file = fake_materialize_schema_db_file
+        schema_repair.run_schema_mismatch_precheck_for_artifact = lambda **kwargs: 0
         artifact = IsoInfo(
             name="ZStack-ZSphere-installer.bin",
             download_url=bin_url,
@@ -208,8 +200,7 @@ class SchemaRepairTest(unittest.TestCase):
         try:
             rc, _artifact, _state = tracker.upgrade(FakeCommand())
         finally:
-            schema_repair.materialize_zsv_schema_db_file = original_materialize
-            schema_repair.run_schema_mismatch_precheck_for_file = original_precheck
+            schema_repair.run_schema_mismatch_precheck_for_artifact = original_precheck
             zsv_service.discover_management_nodes = original_discover
 
         self.assertEqual(0, rc)
@@ -229,11 +220,9 @@ class SchemaRepairTest(unittest.TestCase):
             runner=runner,
         )
         original_discover = zsv_service.discover_management_nodes
-        original_precheck = schema_repair.run_schema_mismatch_precheck_for_file
-        original_materialize = schema_repair.materialize_zsv_schema_db_file
+        original_precheck = schema_repair.run_schema_mismatch_precheck_for_artifact
         zsv_service.discover_management_nodes = lambda address, runner: [address]
-        schema_repair.run_schema_mismatch_precheck_for_file = lambda **kwargs: 0
-        schema_repair.materialize_zsv_schema_db_file = fake_materialize_schema_db_file
+        schema_repair.run_schema_mismatch_precheck_for_artifact = lambda **kwargs: 0
         artifact = IsoInfo(
             name="ZStack-ZSphere-installer.bin",
             download_url=bin_url,
@@ -252,8 +241,7 @@ class SchemaRepairTest(unittest.TestCase):
         try:
             rc, _artifact, _state = tracker.upgrade(FakeCommand())
         finally:
-            schema_repair.materialize_zsv_schema_db_file = original_materialize
-            schema_repair.run_schema_mismatch_precheck_for_file = original_precheck
+            schema_repair.run_schema_mismatch_precheck_for_artifact = original_precheck
             zsv_service.discover_management_nodes = original_discover
 
         self.assertEqual(0, rc)
@@ -281,11 +269,9 @@ class SchemaRepairTest(unittest.TestCase):
             runner=runner,
         )
         original_discover = zsv_service.discover_management_nodes
-        original_precheck = schema_repair.run_schema_mismatch_precheck_for_file
-        original_materialize = schema_repair.materialize_zsv_schema_db_file
+        original_precheck = schema_repair.run_schema_mismatch_precheck_for_artifact
         zsv_service.discover_management_nodes = lambda address, runner: [address]
-        schema_repair.run_schema_mismatch_precheck_for_file = lambda **kwargs: 0
-        schema_repair.materialize_zsv_schema_db_file = fake_materialize_schema_db_file
+        schema_repair.run_schema_mismatch_precheck_for_artifact = lambda **kwargs: 0
         artifact = IsoInfo(
             name="ZStack-ZSphere-installer.bin",
             download_url=bin_url,
@@ -304,8 +290,7 @@ class SchemaRepairTest(unittest.TestCase):
         try:
             rc, _artifact, _state = tracker.upgrade(FakeCommand())
         finally:
-            schema_repair.materialize_zsv_schema_db_file = original_materialize
-            schema_repair.run_schema_mismatch_precheck_for_file = original_precheck
+            schema_repair.run_schema_mismatch_precheck_for_artifact = original_precheck
             zsv_service.discover_management_nodes = original_discover
 
         self.assertEqual(1, rc)
@@ -331,11 +316,9 @@ class SchemaRepairTest(unittest.TestCase):
             runner=runner,
         )
         original_discover = zsv_service.discover_management_nodes
-        original_precheck = schema_repair.run_schema_mismatch_precheck_for_file
-        original_materialize = schema_repair.materialize_zsv_schema_db_file
+        original_precheck = schema_repair.run_schema_mismatch_precheck_for_artifact
         zsv_service.discover_management_nodes = lambda address, runner: [address]
-        schema_repair.run_schema_mismatch_precheck_for_file = lambda **kwargs: 0
-        schema_repair.materialize_zsv_schema_db_file = fake_materialize_schema_db_file
+        schema_repair.run_schema_mismatch_precheck_for_artifact = lambda **kwargs: 0
         artifact = IsoInfo(
             name="ZStack-ZSphere-installer.bin",
             download_url=bin_url,
@@ -354,8 +337,7 @@ class SchemaRepairTest(unittest.TestCase):
         try:
             rc, _artifact, _state = tracker.upgrade(FakeCommand())
         finally:
-            schema_repair.materialize_zsv_schema_db_file = original_materialize
-            schema_repair.run_schema_mismatch_precheck_for_file = original_precheck
+            schema_repair.run_schema_mismatch_precheck_for_artifact = original_precheck
             zsv_service.discover_management_nodes = original_discover
 
         self.assertEqual(1, rc)
@@ -590,13 +572,11 @@ class SchemaRepairTest(unittest.TestCase):
             runner=runner,
         )
         original_discover = zsv_service.discover_management_nodes
-        original_precheck = schema_repair.run_schema_mismatch_precheck_for_file
-        original_materialize = schema_repair.materialize_zsv_schema_db_file
+        original_precheck = schema_repair.run_schema_mismatch_precheck_for_artifact
         zsv_service.discover_management_nodes = (
             lambda address, runner: ["172.26.213.50", "172.26.213.51"]
         )
-        schema_repair.run_schema_mismatch_precheck_for_file = lambda **kwargs: 0
-        schema_repair.materialize_zsv_schema_db_file = fake_materialize_schema_db_file
+        schema_repair.run_schema_mismatch_precheck_for_artifact = lambda **kwargs: 0
         iso = IsoInfo(
             name="ZStack-ZSphere-installer.bin",
             download_url="http://example.invalid/ZStack-ZSphere-installer.bin",
@@ -624,8 +604,7 @@ class SchemaRepairTest(unittest.TestCase):
         try:
             rc, _iso, _state = tracker.upgrade(FakeCommand())
         finally:
-            schema_repair.materialize_zsv_schema_db_file = original_materialize
-            schema_repair.run_schema_mismatch_precheck_for_file = original_precheck
+            schema_repair.run_schema_mismatch_precheck_for_artifact = original_precheck
             zsv_service.discover_management_nodes = original_discover
 
         self.assertEqual(0, rc)
@@ -659,10 +638,9 @@ class SchemaRepairTest(unittest.TestCase):
             "\n".join(logs.output),
         )
 
-    def test_upgrade_resolves_db_file_from_base_ref(self):
+    def test_upgrade_prechecks_schema_from_exact_artifact(self):
         runner = FakeRunner()
         prechecks = []
-        materialized = []
         tracker = ZSphereTracker(
             name="test-env",
             upgrade_type="iso",
@@ -670,26 +648,18 @@ class SchemaRepairTest(unittest.TestCase):
             primary_node="172.26.213.50",
             runner=runner,
         )
-        original_precheck = schema_repair.run_schema_mismatch_precheck_for_file
+        original_precheck = schema_repair.run_schema_mismatch_precheck_for_artifact
         original_discover = zsv_service.discover_management_nodes
-        original_materialize = schema_repair.materialize_zsv_schema_db_file
-
-        def fake_materialize(target_dir, **_kwargs):
-            path = Path(target_dir, "V5.1.0__schema.sql")
-            path.write_text("CREATE TABLE T(id int);\n", encoding="utf-8")
-            materialized.append(str(path))
-            return str(path)
 
         def fake_precheck(**kwargs):
-            prechecks.append((kwargs, Path(kwargs["db_file"]).read_text(encoding="utf-8")))
+            prechecks.append(kwargs)
             return 0
 
-        schema_repair.run_schema_mismatch_precheck_for_file = fake_precheck
+        schema_repair.run_schema_mismatch_precheck_for_artifact = fake_precheck
         zsv_service.discover_management_nodes = lambda address, runner: [address]
-        schema_repair.materialize_zsv_schema_db_file = fake_materialize
         iso = IsoInfo(
-            name="ZStack-ZSphere-installer.bin",
-            download_url="http://example.invalid/ZStack-ZSphere-installer.bin",
+            name="ZStack-ZSphere-x86_64-DVD.iso",
+            download_url="http://example.invalid/ZStack-ZSphere-x86_64-DVD.iso",
             size="123",
         )
         state = SimpleNamespace(
@@ -705,52 +675,38 @@ class SchemaRepairTest(unittest.TestCase):
         try:
             rc, _iso, _state = tracker.upgrade(FakeCommand())
         finally:
-            schema_repair.materialize_zsv_schema_db_file = original_materialize
-            schema_repair.run_schema_mismatch_precheck_for_file = original_precheck
+            schema_repair.run_schema_mismatch_precheck_for_artifact = original_precheck
             zsv_service.discover_management_nodes = original_discover
 
         self.assertEqual(0, rc)
-        self.assertEqual(1, len(materialized))
         self.assertEqual(1, len(prechecks))
-        self.assertEqual("172.26.213.50", prechecks[0][0]["address"])
-        self.assertTrue(prechecks[0][0]["db_file"].endswith("V5.1.0__schema.sql"))
-        self.assertEqual("CREATE TABLE T(id int);\n", prechecks[0][1])
+        self.assertEqual("172.26.213.50", prechecks[0]["address"])
+        self.assertEqual("http://example.invalid/ZStack-ZSphere-x86_64-DVD.iso", prechecks[0]["artifact_url"])
+        self.assertEqual("ZStack-ZSphere-x86_64-DVD.iso", prechecks[0]["artifact_name"])
+        self.assertEqual("123", prechecks[0]["artifact_size"])
+        self.assertEqual("iso", prechecks[0]["upgrade_type"])
         self.assertIn("zsv_upgrade_latest", runner.commands[0][0][-1])
 
-    def test_materialize_zsv_schema_db_file_reuses_compile_base_ref_sync(self):
-        sync_calls = []
-        read_calls = []
-        original_base_ref = schema_repair.zsv_base_ref
-        original_sync = schema_repair.zsv_base_ref_helper.sync_base_ref
-        original_read = schema_repair.read_branch_file
+    def test_artifact_schema_precheck_invokes_remote_artifact_helper(self):
+        runner = FakeRunner()
 
-        def fake_read(root, branch, path):
-            read_calls.append((root, branch, path))
-            return "CREATE TABLE T(id int);\n"
-
-        schema_repair.zsv_base_ref = lambda: "origin/zsv_5.1.0"
-        schema_repair.zsv_base_ref_helper.sync_base_ref = (
-            lambda root: sync_calls.append(root) or True
+        rc = schema_repair.run_schema_mismatch_precheck_for_artifact(
+            address="172.26.213.50",
+            artifact_url="http://example.invalid/ZStack-ZSphere-installer.bin",
+            artifact_name="ZStack-ZSphere-installer.bin",
+            artifact_modified="2026-07-23T13:39:45+08:00",
+            artifact_size="123",
+            upgrade_type="bin",
+            runner=runner,
         )
-        schema_repair.read_branch_file = fake_read
 
-        try:
-            with tempfile.TemporaryDirectory() as td:
-                path = schema_repair.materialize_zsv_schema_db_file(
-                    target_dir=td,
-                    zstack_root="/repo/zstack",
-                )
-
-                self.assertEqual("CREATE TABLE T(id int);\n", Path(path).read_text(encoding="utf-8"))
-        finally:
-            schema_repair.zsv_base_ref = original_base_ref
-            schema_repair.zsv_base_ref_helper.sync_base_ref = original_sync
-            schema_repair.read_branch_file = original_read
-
-        self.assertEqual(["/repo/zstack"], sync_calls)
-        self.assertEqual([
-            ("/repo/zstack", "origin/zsv_5.1.0", "conf/db/zsv/V5.1.0__schema.sql"),
-        ], read_calls)
+        self.assertEqual(0, rc)
+        script = runner.commands[0][0][-1]
+        self.assertIn("zsv_schema_precheck_artifact", script)
+        self.assertIn("http://example.invalid/ZStack-ZSphere-installer.bin", script)
+        self.assertIn("ZStack-ZSphere-installer.bin", script)
+        self.assertIn("2026-07-23T13:39:45+08:00", script)
+        self.assertTrue(script.rstrip().endswith(" bin"))
 
     def test_file_schema_precheck_uses_single_configured_db_file(self):
         staged_files = []
@@ -859,11 +815,62 @@ class SchemaRepairTest(unittest.TestCase):
         self.assertIn("applied checksum: -152505803", output)
         self.assertIn("resolved checksum: -373519170", output)
 
+    def test_artifact_schema_precheck_reports_mismatch_without_shell_errno_log(self):
+        class MismatchRunner(FakeRunner):
+            def run_command(self, cmd, **kwargs):
+                self.commands.append((cmd, kwargs))
+                return subprocess.CompletedProcess(
+                    args=cmd,
+                    returncode=1,
+                    stdout=(
+                        "__CBOK_ZSV_SCHEMA_PRECHECK__\n"
+                        "primary_node=172.26.213.50\n"
+                        "sql_source=/var/lib/cbok/zsv-upgrade/ZStack-ZSphere-installer.bin\n"
+                        "script=V5.1.0__schema.sql\n"
+                        "version=5.1.0\n"
+                        "version_rank=168\n"
+                        "applied_checksum=-152505803\n"
+                        "resolved_checksum=-373519170\n"
+                    ),
+                    stderr="",
+                )
+
+        runner = MismatchRunner()
+
+        with self.assertLogs(schema_repair.LOG, level="ERROR") as logs:
+            rc = schema_repair.run_schema_mismatch_precheck_for_artifact(
+                address="172.26.213.50",
+                artifact_url="http://example.invalid/ZStack-ZSphere-installer.bin",
+                artifact_name="ZStack-ZSphere-installer.bin",
+                artifact_modified="",
+                artifact_size="",
+                upgrade_type="bin",
+                runner=runner,
+            )
+
+        output = "\n".join(logs.output)
+        self.assertEqual(1, rc)
+        self.assertIn(schema_repair.MANUAL_REPAIR_SKILL, output)
+        self.assertIn("SQL source: /var/lib/cbok/zsv-upgrade/ZStack-ZSphere-installer.bin", output)
+        self.assertNotIn("ERRNO: 1 ;<", output)
+        self.assertEqual(False, runner.commands[0][1]["cmd_purge_output"])
+        self.assertEqual(False, runner.commands[0][1]["log_failed_status"])
+
     def test_scriptlet_keeps_only_schema_precheck_helpers(self):
         scriptlet = Path("scriptlet/lib/zsv.sh").read_text(encoding="utf-8")
 
         self.assertIn("zsv_schema_stage_sql_dir()", scriptlet)
         self.assertIn("zsv_schema_flyway_migrate()", scriptlet)
+        self.assertIn("zsv_schema_precheck_artifact()", scriptlet)
+        self.assertIn("_zsv_extract_schema_from_bin()", scriptlet)
+        self.assertIn("_zsv_extract_schema_from_iso()", scriptlet)
+        self.assertIn("WEB-INF/classes/db/zsv/", scriptlet)
+        self.assertIn("expected exactly one", scriptlet)
+        self.assertIn("ZSV schema version from artifact", scriptlet)
+        self.assertIn("ZSV schema SQL for", scriptlet)
+        self.assertIn("applied ZSV schema row for", scriptlet)
+        self.assertIn("zstack-installer.bin", scriptlet)
+        self.assertIn("zstack.war", scriptlet)
         self.assertIn('bash \\"\\$flyway\\" migrate', scriptlet)
         self.assertNotIn("zsv_schema_flyway_repair()", scriptlet)
         self.assertNotIn("zsv_schema_apply_sql_file()", scriptlet)
@@ -873,6 +880,7 @@ class SchemaRepairTest(unittest.TestCase):
 
         self.assertIn("_cbok_export_func zsv_schema_stage_sql_dir", bootstrap)
         self.assertIn("_cbok_export_func zsv_schema_flyway_migrate", bootstrap)
+        self.assertIn("_cbok_export_func zsv_schema_precheck_artifact", bootstrap)
         self.assertNotIn("_cbok_export_func zsv_schema_flyway_repair", bootstrap)
         self.assertNotIn("_cbok_export_func zsv_schema_apply_sql_file", bootstrap)
 

--- a/cbok/utils.py
+++ b/cbok/utils.py
@@ -187,7 +187,8 @@ class UnifiedProcessRunner:
         LOG.error(f"[{self.log_prefix}] ERRNO: {returncode} ;<")
 
     def run_command(self, cmd, args=None, shell=False, cwd=None, env=None,
-                    timeout=None, check=False, cmd_purge_output=False):
+                    timeout=None, check=False, cmd_purge_output=False,
+                    log_output=True, log_failed_status=True):
         if isinstance(cmd, str):
             full_cmd = [cmd]
         else:
@@ -237,7 +238,8 @@ class UnifiedProcessRunner:
                         if cmd_purge_output:
                             print(line)
                             continue
-                        LOG.info(f"[{self.log_prefix}] {line}")
+                        if log_output:
+                            LOG.info(f"[{self.log_prefix}] {line}")
                 proc.stdout.close()
 
             # WARNING: DONOT use `sh/bash -c` to call remote in first shell
@@ -255,7 +257,7 @@ class UnifiedProcessRunner:
 
             output_thread.join(timeout=1)
 
-            if proc.returncode != 0:
+            if proc.returncode != 0 and log_failed_status:
                 self._print_failed_status(proc.returncode)
 
             result = subprocess.CompletedProcess(

--- a/scriptlet/bootstrap.sh
+++ b/scriptlet/bootstrap.sh
@@ -74,6 +74,8 @@ _cbok_export_func zsv_authorize_public_keys
 _cbok_export_func zsv_perform_upgrade
 _cbok_export_func zsv_upgrade_latest
 _cbok_export_func zsv_mysql_query
+_cbok_export_func zsv_schema_precheck_artifact
+_cbok_export_func zsv_schema_precheck_local_artifact
 _cbok_export_func zsv_schema_stage_sql_dir
 _cbok_export_func zsv_schema_flyway_migrate
 

--- a/scriptlet/lib/zsv.sh
+++ b/scriptlet/lib/zsv.sh
@@ -410,7 +410,7 @@ zsv_upgrade_latest() {
     /var/lib/cbok/zsv-upgrade "$expected_modified" "$expected_size" "$upgrade_type"
 }
 
-# --- ZStack dev: check local-base ZSV schema drift before upgrade ---
+# --- ZStack dev: check package ZSV schema drift before upgrade ---
 
 zsv_mysql_query() {
   local address="${1:?address required}"
@@ -422,6 +422,286 @@ zsv_mysql_query() {
 require_cmd mysql
 mysql -uzstack -pzstack.password -N -B -e ${sql_q}
 "
+}
+
+_zsv_sql_string() {
+  local value="${1:-}"
+  printf "'"
+  printf '%s' "$value" | sed "s/'/''/g"
+  printf "'"
+}
+
+_zsv_expect_one_line() {
+  local list_file="${1:?list file required}"
+  local label="${2:?label required}"
+  local content count
+  content=$(awk 'NF' "$list_file" || true)
+  if [[ -z "$content" ]]; then
+    count=0
+  else
+    count=$(printf '%s\n' "$content" | wc -l | tr -d ' ')
+  fi
+  if [[ "$count" != "1" ]]; then
+    echo "expected exactly one ${label}, found ${count}" >&2
+    if [[ -n "$content" ]]; then
+      printf '%s\n' "$content" | sed 's/^/  /' >&2 || true
+    fi
+    return 1
+  fi
+  printf '%s\n' "$content"
+}
+
+_zsv_unpack_installer_bin() {
+  local bin_path="${1:?installer bin required}"
+  local output_dir="${2:?output dir required}"
+  local lines payload_lines
+
+  [[ -f "$bin_path" ]] || die "installer bin missing: $bin_path"
+  mkdir -p "$output_dir"
+  lines=$(wc -l < "$bin_path" | tr -d ' ')
+  payload_lines=$((lines - 11))
+  (( payload_lines > 0 )) || die "invalid installer bin payload: $bin_path"
+  tail -n "$payload_lines" "$bin_path" | tar x -C "$output_dir"
+}
+
+_zsv_versions_from_text() {
+  local text="${1:-}"
+  printf '%s\n' "$text" \
+    | grep -Eo '(^|[^0-9])([0-9]+\.){2,3}[0-9]([^0-9]|$)' \
+    | sed -E 's/^[^0-9]*//; s/[^0-9]*$//' \
+    | sort -u || true
+}
+
+_zsv_artifact_schema_version() {
+  local artifact_url="${1:?artifact url required}"
+  local artifact_name="${2:?artifact name required}"
+  local versions count
+
+  versions=$(_zsv_versions_from_text "$artifact_name")
+  count=$(printf '%s\n' "$versions" | awk 'NF' | wc -l | tr -d ' ')
+  if [[ "$count" != "0" ]]; then
+    _zsv_expect_one_line <(printf '%s\n' "$versions" | awk 'NF') \
+      "ZSV schema version from artifact name"
+    return $?
+  fi
+
+  versions=$(_zsv_versions_from_text "$artifact_url")
+  _zsv_expect_one_line <(printf '%s\n' "$versions" | awk 'NF') \
+    "ZSV schema version from artifact URL"
+}
+
+_zsv_extract_schema_from_war() {
+  local war_path="${1:?zstack war required}"
+  local sql_dir="${2:?sql dir required}"
+  local source_label="${3:?source label required}"
+  local workdir="${4:?workdir required}"
+  local target_version="${5:?target version required}"
+  local entries entry target
+
+  require_cmd unzip
+  [[ -f "$war_path" ]] || die "zstack.war missing: $war_path"
+  mkdir -p "$sql_dir"
+  entries="${workdir}/zsv-schema-entries.txt"
+  unzip -Z -1 "$war_path" \
+    | awk -v prefix="WEB-INF/classes/db/zsv/V${target_version}__" \
+        'index($0, prefix) == 1 && $0 ~ /\.sql$/ && substr($0, length(prefix) + 1) !~ /\//' \
+        > "$entries"
+  if ! entry=$(_zsv_expect_one_line "$entries" "ZSV schema SQL for ${target_version}"); then
+    return 1
+  fi
+  target="${sql_dir}/$(basename "$entry")"
+  unzip -p "$war_path" "$entry" > "$target"
+  printf '%s!%s\n' "$source_label" "$entry" > "${target}.source"
+}
+
+_zsv_extract_schema_from_tgz() {
+  local tgz_path="${1:?zstack tgz required}"
+  local sql_dir="${2:?sql dir required}"
+  local workdir="${3:?workdir required}"
+  local source_label="${4:?source label required}"
+  local target_version="${5:?target version required}"
+  local entries war_entry war_path
+
+  [[ -f "$tgz_path" ]] || die "zstack tgz missing: $tgz_path"
+  entries="${workdir}/zstack-war-entries.txt"
+  tar -tzf "$tgz_path" | grep -E '(^|/)zstack\.war$' > "$entries" || true
+  if ! war_entry=$(_zsv_expect_one_line "$entries" "zstack.war"); then
+    return 1
+  fi
+  tar -xzf "$tgz_path" -C "$workdir" "$war_entry"
+  war_path="${workdir}/${war_entry}"
+  _zsv_extract_schema_from_war "$war_path" "$sql_dir" "$source_label" "$workdir" "$target_version"
+}
+
+_zsv_extract_schema_from_bin() {
+  local bin_path="${1:?installer bin required}"
+  local sql_dir="${2:?sql dir required}"
+  local workdir="${3:?workdir required}"
+  local target_version="${4:?target version required}"
+  local unpack_dir entries tgz_path
+
+  unpack_dir="${workdir}/bin-unpack"
+  mkdir -p "$unpack_dir"
+  _zsv_unpack_installer_bin "$bin_path" "$unpack_dir"
+  entries="${workdir}/zstack-tgz-entries.txt"
+  find "$unpack_dir" -maxdepth 1 -type f -name 'zstack*.tgz' -print > "$entries"
+  if ! tgz_path=$(_zsv_expect_one_line "$entries" "zstack tgz"); then
+    return 1
+  fi
+  _zsv_extract_schema_from_tgz "$tgz_path" "$sql_dir" "$workdir" "$bin_path" "$target_version"
+}
+
+_zsv_extract_schema_from_iso() {
+  local iso_path="${1:?iso required}"
+  local sql_dir="${2:?sql dir required}"
+  local workdir="${3:?workdir required}"
+  local target_version="${4:?target version required}"
+  local mnt installer
+
+  require_cmd mount
+  [[ -f "$iso_path" ]] || die "ISO missing: $iso_path"
+  mnt="${workdir}/iso-mnt"
+  mkdir -p "$mnt"
+  mount -o loop,ro "$iso_path" "$mnt"
+  printf '%s\n' "$mnt" >> "${workdir}/mounts"
+  installer="${mnt}/zstack-installer.bin"
+  [[ -f "$installer" ]] || die "zstack-installer.bin not found in ISO: $iso_path"
+  _zsv_extract_schema_from_bin "$installer" "$sql_dir" "$workdir" "$target_version"
+}
+
+_zsv_extract_schema_from_artifact() {
+  local artifact_path="${1:?artifact path required}"
+  local upgrade_type="${2:?upgrade type required}"
+  local sql_dir="${3:?sql dir required}"
+  local workdir="${4:?workdir required}"
+  local target_version="${5:?target version required}"
+
+  case "$upgrade_type" in
+    bin)
+      _zsv_extract_schema_from_bin "$artifact_path" "$sql_dir" "$workdir" "$target_version"
+      ;;
+    iso)
+      _zsv_extract_schema_from_iso "$artifact_path" "$sql_dir" "$workdir" "$target_version"
+      ;;
+    *)
+      die "unsupported upgrade type: $upgrade_type"
+      ;;
+  esac
+}
+
+_zsv_schema_mysql_local() {
+  local sql="${1:?sql required}"
+  _zsv_health_mysql "$sql"
+}
+
+_zsv_flyway_checksum() {
+  local sql_file="${1:?sql file required}"
+  python - "$sql_file" <<'PY'
+import sys
+import zlib
+
+checksum = 0
+first = True
+with open(sys.argv[1], "rb") as f:
+    for line in f:
+        if line.endswith(b"\n"):
+            line = line[:-1]
+        if line.endswith(b"\r"):
+            line = line[:-1]
+        if first and line.startswith(b"\xef\xbb\xbf"):
+            line = line[3:]
+        first = False
+        checksum = zlib.crc32(line, checksum) & 0xffffffff
+if checksum >= 0x80000000:
+    checksum -= 0x100000000
+print(checksum)
+PY
+}
+
+zsv_schema_precheck_local_artifact() {
+  local artifact_url="${1:?artifact_url required}"
+  local artifact_name="${2:?artifact_name required}"
+  local workdir="${3:-/var/lib/cbok/zsv-upgrade}"
+  local expected_modified="${4:-}"
+  local expected_size="${5:-}"
+  local upgrade_type="${6:-iso}"
+  local db_address="${7:?db address required}"
+  local artifact_path tmp sql_dir schema_file source_label script version script_sql row
+  local migration_version version_rank applied_checksum applied_script resolved_checksum
+
+  _zsv_download_artifact "$artifact_url" "$artifact_name" "$workdir" \
+    "$expected_modified" "$expected_size"
+  artifact_path="${workdir}/${artifact_name}"
+
+  tmp=$(mktemp -d /tmp/cbok-zsv-schema-artifact.XXXXXX)
+  _zsv_schema_precheck_cleanup() {
+    if [[ -f "${tmp}/mounts" ]]; then
+      tac "${tmp}/mounts" | while IFS= read -r mountpoint; do
+        [[ -n "$mountpoint" ]] || continue
+        umount "$mountpoint" >/dev/null 2>&1 || true
+      done
+    fi
+    rm -rf "$tmp"
+  }
+  trap _zsv_schema_precheck_cleanup RETURN
+
+  sql_dir="${tmp}/sql"
+  mkdir -p "$sql_dir"
+  if ! version=$(_zsv_artifact_schema_version "$artifact_url" "$artifact_name"); then
+    return 1
+  fi
+  if ! _zsv_extract_schema_from_artifact "$artifact_path" "$upgrade_type" "$sql_dir" "$tmp" "$version"; then
+    return 1
+  fi
+  if ! schema_file=$(_zsv_expect_one_line <(find "$sql_dir" -maxdepth 1 -type f -name '*.sql' -print | sort) \
+      "extracted ZSV schema SQL"); then
+    return 1
+  fi
+  script=$(basename "$schema_file")
+  script_sql=$(_zsv_sql_string "$script")
+
+  row=$(_zsv_schema_mysql_local "SELECT version, version_rank, IFNULL(checksum, ''), script FROM zstack.schema_version WHERE success = 1 AND script = ${script_sql}" || true)
+  if [[ -z "$row" ]]; then
+    log_info "Package ZSV schema migration ${script} has not been applied on ${db_address}; skip checksum precheck."
+    return 0
+  fi
+  if ! row=$(_zsv_expect_one_line <(printf '%s\n' "$row" | awk 'NF') \
+      "applied ZSV schema row for ${script}"); then
+    return 1
+  fi
+  IFS=$'\t' read -r migration_version version_rank applied_checksum applied_script <<< "$row"
+  source_label=$(cat "${schema_file}.source")
+  resolved_checksum=$(_zsv_flyway_checksum "$schema_file")
+
+  if [[ "$applied_checksum" == "$resolved_checksum" ]]; then
+    log_info "ZSV schema checksum already matches ${source_label}."
+    return 0
+  fi
+
+  printf '%s\n' "__CBOK_ZSV_SCHEMA_PRECHECK__"
+  printf 'primary_node=%s\n' "$db_address"
+  printf 'artifact_path=%s\n' "$artifact_path"
+  printf 'sql_source=%s\n' "$source_label"
+  printf 'script=%s\n' "$applied_script"
+  printf 'version=%s\n' "${migration_version:-$version}"
+  printf 'version_rank=%s\n' "$version_rank"
+  printf 'applied_checksum=%s\n' "$applied_checksum"
+  printf 'resolved_checksum=%s\n' "$resolved_checksum"
+  return 1
+}
+
+zsv_schema_precheck_artifact() {
+  local address="${1:?address required}"
+  local artifact_url="${2:?artifact_url required}"
+  local artifact_name="${3:?artifact_name required}"
+  local expected_modified="${4:-}"
+  local expected_size="${5:-}"
+  local upgrade_type="${6:-iso}"
+
+  ensure_remote_scriptlet "$address"
+  remote_exec "$address" zsv_schema_precheck_local_artifact \
+    "$artifact_url" "$artifact_name" /var/lib/cbok/zsv-upgrade \
+    "$expected_modified" "$expected_size" "$upgrade_type" "$address"
 }
 
 zsv_schema_stage_sql_dir() {


### PR DESCRIPTION
## Summary
- Resolve the ZSV upgrade schema precheck from the exact BIN/ISO package on the primary node instead of local base_ref SQL.
- Parse the target schema version from the package name or URL, require exactly one matching `WEB-INF/classes/db/zsv/V<version>__*.sql`, and compare its Flyway checksum when the migration is already applied.
- Keep checksum mismatch handling as a stop-and-hint path for the `cbok-zsv-upgrade-db-repair` skill, without automatic SQL apply or `flyway repair`.
- Suppress expected intermediate shell `ERRNO` logging for artifact precheck failures so the user sees the structured error/hint.

## Tests
- `CBOK_CONF=/Users/mizar/Workspace/Cursor/me/cbok/cbok.conf PYTHONPATH=$PWD /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest discover -s cbok/test`
- `bash -n scriptlet/lib/zsv.sh scriptlet/bootstrap.sh`
- `python -c "import pathlib; files=['cbok/bbx/zsv/schema_repair.py','cbok/bbx/zsv/service.py','cbok/utils.py','cbok/cmd/zsv.py']; [compile(pathlib.Path(f).read_text(), f, 'exec') for f in files]"`
- `git diff --check`
- On `172.26.50.70`, synced the scriptlet and verified a remote fake BIN with historical `V5.0.2` plus target `V5.1.0` selects only `V5.1.0__schema.sql`; duplicate target SQL returns `expected exactly one ... found 2`; missing target SQL returns `expected exactly one ... found 0`.