### PR TITLE
Guard cbok rebase against dirty source checkouts

### DIFF
--- a/cbok/cmd/base.py
+++ b/cbok/cmd/base.py
@@ -1,8 +1,15 @@
+import logging
 import os
 import shlex
 
 from cbok import utils as cbok_utils
 from cbok.cmd import args
+
+
+LOG = logging.getLogger(__name__)
+FORCE_ABORT_PROMPT = (
+    "Discard local CBoK source changes and abort any rebase? Type 'yes' to continue: "
+)
 
 
 def _source_project_root():
@@ -32,15 +39,84 @@ class DefaultCommands(BaseCommand):
         super().__init__()
         self.project_root = os.path.realpath(project_root or _source_project_root())
 
+    def _git(self, *git_args, **kwargs):
+        return self.p_runner.run_command(
+            ["git", "-C", self.project_root] + list(git_args),
+            **kwargs,
+        )
+
+    def _source_checkout_is_dirty(self) -> bool | None:
+        result = self._git("status", "--porcelain", log_output=False)
+        if result.returncode != 0:
+            LOG.error("Unexpected error while checking CBoK source checkout before rebase.")
+            return None
+        return bool((result.stdout or "").strip())
+
+    def _confirm_force_abort(self) -> bool:
+        try:
+            answer = input(FORCE_ABORT_PROMPT)
+        except EOFError:
+            LOG.error("Force abort requires interactive confirmation.")
+            return False
+        if answer.strip() != "yes":
+            LOG.error("Force abort cancelled; confirmation was not yes.")
+            return False
+        return True
+
+    def _force_abort_source_checkout(self):
+        self._git(
+            "rebase", "--abort",
+            cmd_purge_output=False,
+            log_output=False,
+            log_failed_status=False,
+        )
+        for git_args in (
+            ("reset", "--hard"),
+            ("clean", "-fd"),
+        ):
+            result = self._git(*git_args)
+            if result.returncode != 0:
+                return result.returncode or 1
+        return 0
+
     @args.action_description("Checkout CBoK source master and rebase origin/master")
-    def rebase(self):
+    @args.args(
+        "--force-abort",
+        action="store_true",
+        help=(
+            "Prompt for confirmation, then abort any in-progress rebase and "
+            "discard local CBoK source changes before rebasing master"),
+    )
+    def rebase(self, force_abort=False):
         """Checkout CBoK source master and rebase it from origin/master."""
+        if force_abort:
+            if not self._confirm_force_abort():
+                return 1
+            force_result = self._force_abort_source_checkout()
+            if force_result != 0:
+                return force_result
+        else:
+            dirty = self._source_checkout_is_dirty()
+            if dirty is None:
+                return 1
+            if dirty:
+                LOG.error(
+                    "Unexpected dirty CBoK source checkout before rebase.\n"
+                    "source: %s\n"
+                    "cbok rebase expects the editable source checkout to be a clean master baseline.\n"
+                    "Inspect it with: git -C %s status --short\n"
+                    "Use cbok rebase --force-abort only if local changes can be discarded.",
+                    self.project_root,
+                    self.project_root,
+                )
+                return 1
+
         for git_args in (
             ["checkout", "master"],
             ["fetch", "origin"],
             ["rebase", "origin/master"],
         ):
-            result = self.p_runner.run_command(["git", "-C", self.project_root] + git_args)
+            result = self._git(*git_args)
             if result.returncode != 0:
                 return result.returncode or 1
         return 0

--- a/cbok/test/test_cmd_base_commands.py
+++ b/cbok/test/test_cmd_base_commands.py
@@ -1,18 +1,31 @@
 import subprocess
 import unittest
+from unittest import mock
 
+from cbok.cmd import base
 from cbok.cmd.base import DefaultCommands
 
 
 class FakeRunner:
-    def __init__(self, returncodes=None):
+    def __init__(self, responses=None, returncodes=None):
         self.commands = []
+        self.kwargs = []
+        self.responses = list(responses or [])
         self.returncodes = list(returncodes or [])
 
-    def run_command(self, cmd):
+    def run_command(self, cmd, **kwargs):
         self.commands.append(cmd)
+        self.kwargs.append(kwargs)
+        if self.responses:
+            response = self.responses.pop(0)
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=response.get("returncode", 0),
+                stdout=response.get("stdout", ""),
+                stderr=response.get("stderr", ""),
+            )
         returncode = self.returncodes.pop(0) if self.returncodes else 0
-        return subprocess.CompletedProcess(args=cmd, returncode=returncode)
+        return subprocess.CompletedProcess(args=cmd, returncode=returncode, stdout="", stderr="")
 
 
 class DefaultCommandsTest(unittest.TestCase):
@@ -26,23 +39,133 @@ class DefaultCommandsTest(unittest.TestCase):
         self.assertEqual(0, result)
         self.assertEqual(
             [
+                ["git", "-C", "/repo/cbok", "status", "--porcelain"],
                 ["git", "-C", "/repo/cbok", "checkout", "master"],
                 ["git", "-C", "/repo/cbok", "fetch", "origin"],
                 ["git", "-C", "/repo/cbok", "rebase", "origin/master"],
             ],
             runner.commands,
         )
+        self.assertEqual(False, runner.kwargs[0]["log_output"])
 
     def test_rebase_stops_on_first_failed_git_command(self):
         command = DefaultCommands(project_root="/repo/cbok")
-        runner = FakeRunner(returncodes=[1])
+        runner = FakeRunner(responses=[
+            {"stdout": ""},
+            {"returncode": 1},
+        ])
         command.p_runner = runner
 
         result = command.rebase()
 
         self.assertEqual(1, result)
         self.assertEqual(
-            [["git", "-C", "/repo/cbok", "checkout", "master"]],
+            [
+                ["git", "-C", "/repo/cbok", "status", "--porcelain"],
+                ["git", "-C", "/repo/cbok", "checkout", "master"],
+            ],
+            runner.commands,
+        )
+
+    def test_rebase_reports_unexpected_dirty_checkout_before_checkout(self):
+        command = DefaultCommands(project_root="/repo/cbok")
+        runner = FakeRunner(responses=[
+            {"stdout": " M cbok/cmd/zsv.py\n?? scratch.py\n"},
+        ])
+        command.p_runner = runner
+
+        with self.assertLogs("cbok.cmd.base", level="ERROR") as logs:
+            result = command.rebase()
+
+        self.assertEqual(1, result)
+        self.assertEqual(
+            [["git", "-C", "/repo/cbok", "status", "--porcelain"]],
+            runner.commands,
+        )
+        self.assertEqual(False, runner.kwargs[0]["log_output"])
+        message = "\n".join(logs.output)
+        self.assertIn("Unexpected dirty CBoK source checkout before rebase", message)
+        self.assertNotIn("cbok/cmd/zsv.py", message)
+        self.assertNotIn("scratch.py", message)
+        self.assertNotIn("Please commit your changes", message)
+
+    def test_rebase_force_abort_discards_changes_before_rebase(self):
+        command = DefaultCommands(project_root="/repo/cbok")
+        runner = FakeRunner(responses=[
+            {"returncode": 1, "stderr": "fatal: No rebase in progress?\n"},
+            {},
+            {},
+            {},
+            {},
+            {},
+        ])
+        command.p_runner = runner
+
+        with mock.patch("builtins.input", return_value="yes") as prompt:
+            result = command.rebase(force_abort=True)
+
+        self.assertEqual(0, result)
+        self.assertEqual(base.FORCE_ABORT_PROMPT, prompt.call_args[0][0])
+        self.assertEqual(
+            [
+                ["git", "-C", "/repo/cbok", "rebase", "--abort"],
+                ["git", "-C", "/repo/cbok", "reset", "--hard"],
+                ["git", "-C", "/repo/cbok", "clean", "-fd"],
+                ["git", "-C", "/repo/cbok", "checkout", "master"],
+                ["git", "-C", "/repo/cbok", "fetch", "origin"],
+                ["git", "-C", "/repo/cbok", "rebase", "origin/master"],
+            ],
+            runner.commands,
+        )
+        self.assertEqual(
+            {"cmd_purge_output": False, "log_output": False, "log_failed_status": False},
+            runner.kwargs[0],
+        )
+
+    def test_rebase_force_abort_stops_when_user_declines(self):
+        command = DefaultCommands(project_root="/repo/cbok")
+        runner = FakeRunner()
+        command.p_runner = runner
+
+        with mock.patch("builtins.input", return_value="no") as prompt:
+            with self.assertLogs("cbok.cmd.base", level="ERROR") as logs:
+                result = command.rebase(force_abort=True)
+
+        self.assertEqual(1, result)
+        self.assertEqual([], runner.commands)
+        self.assertEqual(base.FORCE_ABORT_PROMPT, prompt.call_args[0][0])
+        self.assertIn("Force abort cancelled", "\n".join(logs.output))
+
+    def test_rebase_force_abort_stops_when_confirmation_is_unavailable(self):
+        command = DefaultCommands(project_root="/repo/cbok")
+        runner = FakeRunner()
+        command.p_runner = runner
+
+        with mock.patch("builtins.input", side_effect=EOFError):
+            with self.assertLogs("cbok.cmd.base", level="ERROR") as logs:
+                result = command.rebase(force_abort=True)
+
+        self.assertEqual(1, result)
+        self.assertEqual([], runner.commands)
+        self.assertIn("Force abort requires interactive confirmation", "\n".join(logs.output))
+
+    def test_rebase_force_abort_stops_when_reset_fails(self):
+        command = DefaultCommands(project_root="/repo/cbok")
+        runner = FakeRunner(responses=[
+            {"returncode": 1},
+            {"returncode": 2},
+        ])
+        command.p_runner = runner
+
+        with mock.patch("builtins.input", return_value="yes"):
+            result = command.rebase(force_abort=True)
+
+        self.assertEqual(2, result)
+        self.assertEqual(
+            [
+                ["git", "-C", "/repo/cbok", "rebase", "--abort"],
+                ["git", "-C", "/repo/cbok", "reset", "--hard"],
+            ],
             runner.commands,
         )
 


### PR DESCRIPTION
## Summary
- Add a preflight dirty-check for `cbok rebase` so it fails with a CBoK unexpected-state error before `git checkout master` can print the generic Git checkout message.
- Add `cbok rebase --force-abort` as an explicit escape hatch that requires interactive `yes` confirmation before aborting an in-progress rebase, discarding local source changes, and continuing the rebase flow.
- Keep the dirty-check output quiet so it does not print the changed file list.

## Tests
- `CBOK_CONF=/Users/mizar/Workspace/Cursor/me/cbok/cbok.conf PYTHONPATH=$PWD /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest cbok.test.test_cmd_base_commands`
- `CBOK_CONF=/Users/mizar/Workspace/Cursor/me/cbok/cbok.conf PYTHONPATH=$PWD /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest discover -s cbok/test`
- `git diff --check`