### PR TITLE
fix(cbok): skip unnecessary force-abort cleanup

### DIFF
--- a/cbok/cmd/base.py
+++ b/cbok/cmd/base.py
@@ -52,6 +52,36 @@ class DefaultCommands(BaseCommand):
             return None
         return bool((result.stdout or "").strip())
 
+    def _git_admin_dir(self):
+        dot_git = os.path.join(self.project_root, ".git")
+        if os.path.isdir(dot_git):
+            return dot_git
+        if not os.path.isfile(dot_git):
+            return None
+        with open(dot_git, encoding="utf-8") as f:
+            marker = f.readline().strip()
+        if not marker.startswith("gitdir:"):
+            return None
+        git_dir = marker.split(":", 1)[1].strip()
+        if not os.path.isabs(git_dir):
+            git_dir = os.path.join(self.project_root, git_dir)
+        return os.path.realpath(git_dir)
+
+    def _rebase_in_progress(self):
+        git_dir = self._git_admin_dir()
+        if not git_dir:
+            return False
+        return any(
+            os.path.exists(os.path.join(git_dir, name))
+            for name in ("rebase-merge", "rebase-apply")
+        )
+
+    def _force_abort_needed(self) -> bool | None:
+        dirty = self._source_checkout_is_dirty()
+        if dirty is None:
+            return None
+        return dirty or self._rebase_in_progress()
+
     def _confirm_force_abort(self) -> bool:
         try:
             answer = input(FORCE_ABORT_PROMPT)
@@ -90,11 +120,15 @@ class DefaultCommands(BaseCommand):
     def rebase(self, force_abort=False):
         """Checkout CBoK source master and rebase it from origin/master."""
         if force_abort:
-            if not self._confirm_force_abort():
+            force_needed = self._force_abort_needed()
+            if force_needed is None:
                 return 1
-            force_result = self._force_abort_source_checkout()
-            if force_result != 0:
-                return force_result
+            if force_needed:
+                if not self._confirm_force_abort():
+                    return 1
+                force_result = self._force_abort_source_checkout()
+                if force_result != 0:
+                    return force_result
         else:
             dirty = self._source_checkout_is_dirty()
             if dirty is None:

--- a/cbok/test/test_cmd_base_commands.py
+++ b/cbok/test/test_cmd_base_commands.py
@@ -1,5 +1,7 @@
 import subprocess
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from cbok.cmd import base
@@ -92,6 +94,7 @@ class DefaultCommandsTest(unittest.TestCase):
     def test_rebase_force_abort_discards_changes_before_rebase(self):
         command = DefaultCommands(project_root="/repo/cbok")
         runner = FakeRunner(responses=[
+            {"stdout": " M cbok/cmd/base.py\n"},
             {"returncode": 1, "stderr": "fatal: No rebase in progress?\n"},
             {},
             {},
@@ -108,6 +111,7 @@ class DefaultCommandsTest(unittest.TestCase):
         self.assertEqual(base.FORCE_ABORT_PROMPT, prompt.call_args[0][0])
         self.assertEqual(
             [
+                ["git", "-C", "/repo/cbok", "status", "--porcelain"],
                 ["git", "-C", "/repo/cbok", "rebase", "--abort"],
                 ["git", "-C", "/repo/cbok", "reset", "--hard"],
                 ["git", "-C", "/repo/cbok", "clean", "-fd"],
@@ -118,13 +122,78 @@ class DefaultCommandsTest(unittest.TestCase):
             runner.commands,
         )
         self.assertEqual(
+            False,
+            runner.kwargs[0]["log_output"],
+        )
+        self.assertEqual(
             {"cmd_purge_output": False, "log_output": False, "log_failed_status": False},
-            runner.kwargs[0],
+            runner.kwargs[1],
+        )
+
+    def test_rebase_force_abort_skips_prompt_when_clean_and_not_rebasing(self):
+        command = DefaultCommands(project_root="/repo/cbok")
+        runner = FakeRunner(responses=[
+            {"stdout": ""},
+            {},
+            {},
+            {},
+        ])
+        command.p_runner = runner
+
+        with mock.patch("builtins.input") as prompt:
+            result = command.rebase(force_abort=True)
+
+        self.assertEqual(0, result)
+        prompt.assert_not_called()
+        self.assertEqual(
+            [
+                ["git", "-C", "/repo/cbok", "status", "--porcelain"],
+                ["git", "-C", "/repo/cbok", "checkout", "master"],
+                ["git", "-C", "/repo/cbok", "fetch", "origin"],
+                ["git", "-C", "/repo/cbok", "rebase", "origin/master"],
+            ],
+            runner.commands,
+        )
+
+    def test_rebase_force_abort_prompts_when_rebase_state_exists_even_if_clean(self):
+        with tempfile.TemporaryDirectory() as td:
+            git_dir = Path(td, ".git")
+            Path(git_dir, "rebase-merge").mkdir(parents=True)
+            command = DefaultCommands(project_root=td)
+            root = command.project_root
+            runner = FakeRunner(responses=[
+                {"stdout": ""},
+                {},
+                {},
+                {},
+                {},
+                {},
+            ])
+            command.p_runner = runner
+
+            with mock.patch("builtins.input", return_value="yes") as prompt:
+                result = command.rebase(force_abort=True)
+
+        self.assertEqual(0, result)
+        self.assertEqual(base.FORCE_ABORT_PROMPT, prompt.call_args[0][0])
+        self.assertEqual(
+            [
+                ["git", "-C", root, "status", "--porcelain"],
+                ["git", "-C", root, "rebase", "--abort"],
+                ["git", "-C", root, "reset", "--hard"],
+                ["git", "-C", root, "clean", "-fd"],
+                ["git", "-C", root, "checkout", "master"],
+                ["git", "-C", root, "fetch", "origin"],
+                ["git", "-C", root, "rebase", "origin/master"],
+            ],
+            runner.commands,
         )
 
     def test_rebase_force_abort_stops_when_user_declines(self):
         command = DefaultCommands(project_root="/repo/cbok")
-        runner = FakeRunner()
+        runner = FakeRunner(responses=[
+            {"stdout": " M cbok/cmd/base.py\n"},
+        ])
         command.p_runner = runner
 
         with mock.patch("builtins.input", return_value="no") as prompt:
@@ -132,13 +201,18 @@ class DefaultCommandsTest(unittest.TestCase):
                 result = command.rebase(force_abort=True)
 
         self.assertEqual(1, result)
-        self.assertEqual([], runner.commands)
+        self.assertEqual(
+            [["git", "-C", "/repo/cbok", "status", "--porcelain"]],
+            runner.commands,
+        )
         self.assertEqual(base.FORCE_ABORT_PROMPT, prompt.call_args[0][0])
         self.assertIn("Force abort cancelled", "\n".join(logs.output))
 
     def test_rebase_force_abort_stops_when_confirmation_is_unavailable(self):
         command = DefaultCommands(project_root="/repo/cbok")
-        runner = FakeRunner()
+        runner = FakeRunner(responses=[
+            {"stdout": " M cbok/cmd/base.py\n"},
+        ])
         command.p_runner = runner
 
         with mock.patch("builtins.input", side_effect=EOFError):
@@ -146,12 +220,16 @@ class DefaultCommandsTest(unittest.TestCase):
                 result = command.rebase(force_abort=True)
 
         self.assertEqual(1, result)
-        self.assertEqual([], runner.commands)
+        self.assertEqual(
+            [["git", "-C", "/repo/cbok", "status", "--porcelain"]],
+            runner.commands,
+        )
         self.assertIn("Force abort requires interactive confirmation", "\n".join(logs.output))
 
     def test_rebase_force_abort_stops_when_reset_fails(self):
         command = DefaultCommands(project_root="/repo/cbok")
         runner = FakeRunner(responses=[
+            {"stdout": " M cbok/cmd/base.py\n"},
             {"returncode": 1},
             {"returncode": 2},
         ])
@@ -163,6 +241,7 @@ class DefaultCommandsTest(unittest.TestCase):
         self.assertEqual(2, result)
         self.assertEqual(
             [
+                ["git", "-C", "/repo/cbok", "status", "--porcelain"],
                 ["git", "-C", "/repo/cbok", "rebase", "--abort"],
                 ["git", "-C", "/repo/cbok", "reset", "--hard"],
             ],


### PR DESCRIPTION
## Summary
- Check whether the CBoK source checkout is dirty or currently rebasing before honoring `cbok rebase --force-abort` cleanup.
- Skip the confirmation prompt and destructive cleanup when the checkout is already clean and not rebasing.
- Add tests for clean skip, dirty confirmation, rebase-state confirmation, and cancellation/failure paths.

## Tests
- `PYTHONDONTWRITEBYTECODE=1 CBOK_CONF=/Users/mizar/Workspace/Cursor/me/cbok/cbok.conf PYTHONPATH=/Users/mizar/Workspace/Cursor/me/cbok/.worktrees/cbok-rebase-force-abort-needed /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest discover cbok/test`
- `git diff --check`