### PR TITLE
fix(cbok): log skipped force-abort cleanup

### DIFF
--- a/cbok/cmd/base.py
+++ b/cbok/cmd/base.py
@@ -129,6 +129,8 @@ class DefaultCommands(BaseCommand):
                 force_result = self._force_abort_source_checkout()
                 if force_result != 0:
                     return force_result
+            else:
+                LOG.info("No need abort.")
         else:
             dirty = self._source_checkout_is_dirty()
             if dirty is None:

--- a/cbok/test/test_cmd_base_commands.py
+++ b/cbok/test/test_cmd_base_commands.py
@@ -141,10 +141,12 @@ class DefaultCommandsTest(unittest.TestCase):
         command.p_runner = runner
 
         with mock.patch("builtins.input") as prompt:
-            result = command.rebase(force_abort=True)
+            with self.assertLogs("cbok.cmd.base", level="INFO") as logs:
+                result = command.rebase(force_abort=True)
 
         self.assertEqual(0, result)
         prompt.assert_not_called()
+        self.assertIn("No need abort.", "\n".join(logs.output))
         self.assertEqual(
             [
                 ["git", "-C", "/repo/cbok", "status", "--porcelain"],


### PR DESCRIPTION
## Summary
- Log `No need abort.` when `cbok rebase --force-abort` finds the source checkout clean and not rebasing.
- Cover the clean skip path with a log assertion.

## Tests
- `PYTHONDONTWRITEBYTECODE=1 CBOK_CONF=/Users/mizar/Workspace/Cursor/me/cbok/cbok.conf PYTHONPATH=/Users/mizar/Workspace/Cursor/me/cbok/.worktrees/cbok-rebase-force-abort-needed /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest cbok.test.test_cmd_base_commands.DefaultCommandsTest.test_rebase_force_abort_skips_prompt_when_clean_and_not_rebasing cbok.test.test_cmd_base_commands`
- `PYTHONDONTWRITEBYTECODE=1 CBOK_CONF=/Users/mizar/Workspace/Cursor/me/cbok/cbok.conf PYTHONPATH=/Users/mizar/Workspace/Cursor/me/cbok/.worktrees/cbok-rebase-force-abort-needed /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest discover cbok/test`
- `git diff --check origin/master..HEAD`