### PR TITLE
chore(zsv): remove unused zstack root resolver

### DIFF
--- a/cbok/bbx/zsv/compile.py
+++ b/cbok/bbx/zsv/compile.py
@@ -26,8 +26,6 @@ from cbok import settings
 from cbok.bbx.models import ZsvCompileState
 from cbok.bbx.zsv import base_ref as zsv_base_ref
 from cbok.bbx.zsv import config as zsv_config
-from cbok.bbx.zsv.config import default_zstack_root
-from cbok.bbx.zsv.config import zstack_root_from_workspace
 from cbok.bbx.zsv.worktree_container import DEFAULT_MIN_FREE_GB
 from cbok.bbx.zsv.worktree_container import WorktreeContainerSpec
 from cbok.bbx.zsv.worktree_container import ensure_worktree_container

--- a/cbok/bbx/zsv/config.py
+++ b/cbok/bbx/zsv/config.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 from cbok import settings
 
 
@@ -9,18 +7,3 @@ def zsv_base_ref() -> str:
     if settings.CONF.has_section("zsv") and settings.CONF.has_option("zsv", "base_ref"):
         return settings.CONF.get("zsv", "base_ref").strip()
     return ""
-
-
-def default_zstack_root() -> str:
-    candidates = [
-        os.path.join(settings.Workspace, "Cursor", "zs", "zstack"),
-        os.path.join(settings.Workspace, "Cursor", "zs", "zstack-workspace", "zstack"),
-    ]
-    for candidate in candidates:
-        if os.path.isdir(candidate):
-            return candidate
-    return candidates[0]
-
-
-def zstack_root_from_workspace() -> str:
-    return os.path.realpath(default_zstack_root())

--- a/cbok/test/zsv/test_config.py
+++ b/cbok/test/zsv/test_config.py
@@ -20,11 +20,9 @@ def _conf(zsv_values=None, zsv_compile_values=None):
 class ZsvConfigTest(unittest.TestCase):
     def setUp(self):
         self._orig_conf = zsv_config.settings.CONF
-        self._orig_workspace = zsv_config.settings.Workspace
 
     def tearDown(self):
         zsv_config.settings.CONF = self._orig_conf
-        zsv_config.settings.Workspace = self._orig_workspace
 
     def test_base_ref_prefers_shared_zsv_config(self):
         zsv_config.settings.CONF = _conf(
@@ -40,12 +38,3 @@ class ZsvConfigTest(unittest.TestCase):
         )
 
         self.assertEqual("", zsv_config.zsv_base_ref())
-
-    def test_zstack_root_is_derived_from_workspace(self):
-        zsv_config.settings.CONF = _conf(zsv_values={"zstack_root": "/ignored/zstack"})
-        zsv_config.settings.Workspace = "/workspace"
-
-        self.assertEqual(
-            "/workspace/Cursor/zs/zstack",
-            zsv_config.zstack_root_from_workspace(),
-        )


### PR DESCRIPTION
## Summary
- Remove the unused zsv default ZStack root resolver that still hardcoded `Cursor/zs` paths.
- Drop stale imports from zsv compile code.
- Remove the test that only covered the deleted hardcoded resolver.

## Tests
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 CBOK_CONF=/Users/mizar/Workspace/Cursor/me/cbok/cbok.conf PYTHONPATH=/Users/mizar/Workspace/Cursor/me/cbok/.worktrees/remove-unused-zsv-path-resolver /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest cbok.test.zsv.test_config`
- `PYTHONDONTWRITEBYTECODE=1 CBOK_CONF=/Users/mizar/Workspace/Cursor/me/cbok/cbok.conf PYTHONPATH=/Users/mizar/Workspace/Cursor/me/cbok/.worktrees/remove-unused-zsv-path-resolver /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest discover cbok/test`