### PR TITLE
chore(zsv): remove legacy compile base ref mention

### DIFF
--- a/cbok/bbx/zsv/README.md
+++ b/cbok/bbx/zsv/README.md
@@ -58,8 +58,7 @@ Behavior:
   directory and deploys from there, without writing build outputs back into the
   source worktree.
 - Uses `[zsv] base_ref` as the shared upstream base for incremental compile
-  changed-path detection. Existing `[zsv_compile] base_ref` values are still
-  accepted for compatibility.
+  changed-path detection.
 
 ## ZSphere upgrade schema file
 

--- a/cbok/test/zsv/test_config.py
+++ b/cbok/test/zsv/test_config.py
@@ -24,17 +24,16 @@ class ZsvConfigTest(unittest.TestCase):
     def tearDown(self):
         zsv_config.settings.CONF = self._orig_conf
 
-    def test_base_ref_prefers_shared_zsv_config(self):
+    def test_base_ref_reads_shared_zsv_config(self):
         zsv_config.settings.CONF = _conf(
             zsv_values={"base_ref": "origin/shared"},
-            zsv_compile_values={"base_ref": "origin/legacy"},
         )
 
         self.assertEqual("origin/shared", zsv_config.zsv_base_ref())
 
-    def test_base_ref_does_not_fall_back_to_legacy_compile_config(self):
+    def test_base_ref_ignores_compile_config(self):
         zsv_config.settings.CONF = _conf(
-            zsv_compile_values={"base_ref": "origin/legacy"},
+            zsv_compile_values={"remote_docker_host": "tcp://172.26.50.70:2375"},
         )
 
         self.assertEqual("", zsv_config.zsv_base_ref())


### PR DESCRIPTION
## Summary
- Remove the stale README statement that `[zsv_compile] base_ref` is accepted for compatibility.
- Update ZSV config tests so they no longer describe a legacy compile base-ref fallback.

## Tests
- `PYTHONDONTWRITEBYTECODE=1 CBOK_CONF=/Users/mizar/Workspace/Cursor/me/cbok/cbok.conf PYTHONPATH=/Users/mizar/Workspace/Cursor/me/cbok/.worktrees/remove-legacy-zsv-compile-base-ref /Users/mizar/Workspace/Cursor/me/cbok/venv/bin/python -m unittest cbok.test.zsv.test_config cbok.test.bbx.test_zsv_compile`
- `git diff --check`